### PR TITLE
Support API version 1.3-rev2 (Veeam B&R 13.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ This project is an independent, open source project. It is not affiliated with, 
 - Home Assistant 2023.1.0 or newer
 - Veeam Backup & Replication server with REST API enabled (Community Edition not supported)
 
+### Supported API Versions
+
+The **API Version** option selects the REST API revision used against your server. It
+defaults to the newest revision; on an older server, pick the revision matching your VBR
+release. Veeam also serves older revisions to newer servers, so a lower revision is a safe
+choice if you are unsure.
+
+| VBR Version | API Version | Notes |
+| ----------- | ----------- | ----- |
+| 13.1.0.411  | `1.3-rev2`  | Default |
+| 13.0.1.180  | `1.3-rev1`  | |
+| 13.0.0.4967 | `1.3-rev0`  | |
+| 12.3.1.1139 | `1.2-rev1`  | |
+
+Older VBR releases are not supported. The list is discovered at runtime from the installed
+[veeam-br](https://github.com/Cenvora/veeam-br) library, so it reflects whichever revisions
+that version ships (`1.3-rev2` requires veeam-br 0.3.0 or newer).
+
 ## Installation
 ### HACS (Recommended)
 

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     API_VERSIONS,
     CONF_API_VERSION,
     CONF_VERIFY_SSL,
+    DEFAULT_API_MODULE,
     DEFAULT_API_VERSION,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -35,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_version = entry.options.get(
         CONF_API_VERSION, entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
     )
-    api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+    api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
     # Import UNSET type for proper type checking
     try:

--- a/custom_components/veeam_br/button.py
+++ b/custom_components/veeam_br/button.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     API_VERSIONS,
     CONF_API_VERSION,
+    DEFAULT_API_MODULE,
     DEFAULT_API_VERSION,
     DOMAIN,
     check_api_feature_availability,
@@ -44,7 +45,7 @@ async def async_setup_entry(
         CONF_API_VERSION,
         entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
     )
-    api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+    api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
     # Pre-import button API endpoints
     button_endpoints = [
@@ -314,7 +315,7 @@ class VeeamRepositoryRescanButton(CoordinatorEntity, ButtonEntity):
                 CONF_API_VERSION,
                 self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
             )
-            api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+            api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # VeeamClient handles token refresh automatically - no manual check needed
 
@@ -413,7 +414,7 @@ class VeeamSOBRExtentEnableSealedModeButton(VeeamSOBRExtentButtonBase):
                 CONF_API_VERSION,
                 self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
             )
-            api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+            api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
             try:
@@ -488,7 +489,7 @@ class VeeamSOBRExtentDisableSealedModeButton(VeeamSOBRExtentButtonBase):
                 CONF_API_VERSION,
                 self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
             )
-            api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+            api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
             try:
@@ -563,7 +564,7 @@ class VeeamSOBRExtentEnableMaintenanceModeButton(VeeamSOBRExtentButtonBase):
                 CONF_API_VERSION,
                 self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
             )
-            api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+            api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
             try:
@@ -639,7 +640,7 @@ class VeeamSOBRExtentDisableMaintenanceModeButton(VeeamSOBRExtentButtonBase):
                 CONF_API_VERSION,
                 self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
             )
-            api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+            api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
             try:
@@ -725,7 +726,7 @@ class VeeamJobButtonBase(CoordinatorEntity, ButtonEntity):
             CONF_API_VERSION,
             self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
         )
-        return API_VERSIONS.get(api_version, "v1_3_rev1")
+        return API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
     async def _import_spec_model(self, spec_name: str):
         """Import a spec model from the veeam_br library.

--- a/custom_components/veeam_br/const.py
+++ b/custom_components/veeam_br/const.py
@@ -15,29 +15,46 @@ CONF_API_VERSION = "api_version"
 # Defaults
 DEFAULT_PORT = 9419
 DEFAULT_VERIFY_SSL = True
-DEFAULT_API_VERSION = "1.3-rev1"
+# Newest API revision shipped by veeam-br, served by Veeam B&R 13.1. Bump this together
+# with FALLBACK_API_VERSIONS when veeam-br adds a revision. Users on older servers can
+# select an older revision in the config flow; the flow validates the connection, so a
+# revision the server does not serve fails at setup rather than silently.
+DEFAULT_API_VERSION = "1.3-rev2"
 
 _LOGGER = logging.getLogger(__name__)
+
+# Fallback used when the veeam-br package cannot be inspected. Mirrors the
+# versions shipped by veeam-br >= 0.3.0 (see veeam_br.versions.VERSION_TO_PACKAGE);
+# 1.3-rev2 is the API version served by Veeam B&R 13.1.
+FALLBACK_API_VERSIONS = {
+    "1.2-rev1": "v1_2_rev1",
+    "1.3-rev0": "v1_3_rev0",
+    "1.3-rev1": "v1_3_rev1",
+    "1.3-rev2": "v1_3_rev2",
+}
+
+# Package directory backing DEFAULT_API_VERSION, used when a stored API version is unknown
+DEFAULT_API_MODULE = FALLBACK_API_VERSIONS[DEFAULT_API_VERSION]
+
+# Pattern to match version directories: v{major}_{minor}_rev{revision}
+_API_VERSION_PATTERN = re.compile(r"^v(\d+)_(\d+)_rev(\d+)$")
 
 
 def _discover_api_versions() -> dict[str, str]:
     """Dynamically discover available API versions from the veeam-br package.
 
     Returns:
-        dict: Mapping of display version (e.g., "1.2-rev1") to module name (e.g., "v1_2_rev1")
+        dict: Mapping of display version (e.g., "1.2-rev1") to module name (e.g., "v1_2_rev1"),
+            ordered oldest to newest.
     """
-    versions = {}
+    discovered: list[tuple[tuple[int, int, int], str, str]] = []
 
     try:
         # Find the veeam_br package
         spec = importlib.util.find_spec("veeam_br")
         if spec is None:
             _LOGGER.warning("veeam_br package not found, using default API versions")
-            return {
-                "1.2-rev1": "v1_2_rev1",
-                "1.3-rev0": "v1_3_rev0",
-                "1.3-rev1": "v1_3_rev1",
-            }
+            return dict(FALLBACK_API_VERSIONS)
 
         # Get the package directory (handle namespace packages)
         if spec.submodule_search_locations:
@@ -46,43 +63,29 @@ def _discover_api_versions() -> dict[str, str]:
             veeam_br_path = os.path.dirname(spec.origin)
         else:
             _LOGGER.warning("Could not determine veeam_br package path, using defaults")
-            return {
-                "1.2-rev1": "v1_2_rev1",
-                "1.3-rev0": "v1_3_rev0",
-                "1.3-rev1": "v1_3_rev1",
-            }
-
-        # Pattern to match version directories: v{major}_{minor}_rev{revision}
-        api_version_pattern = re.compile(r"^v(\d+)_(\d+)_rev(\d+)$")
+            return dict(FALLBACK_API_VERSIONS)
 
         # Scan for version directories
         for item in os.listdir(veeam_br_path):
-            item_path = os.path.join(veeam_br_path, item)
-            if os.path.isdir(item_path) and api_version_pattern.match(item):
-                match = api_version_pattern.match(item)
-                if match:
-                    major, minor, rev = match.groups()
-                    # Convert to display format: "1.2-rev1"
-                    display_version = f"{major}.{minor}-rev{rev}"
-                    versions[display_version] = item
+            match = _API_VERSION_PATTERN.match(item)
+            if match and os.path.isdir(os.path.join(veeam_br_path, item)):
+                major, minor, rev = match.groups()
+                # Convert to display format: "1.2-rev1"
+                display_version = f"{major}.{minor}-rev{rev}"
+                discovered.append(((int(major), int(minor), int(rev)), display_version, item))
 
-        if not versions:
+        if not discovered:
             _LOGGER.warning("No API versions found in veeam_br package, using defaults")
-            return {
-                "1.2-rev1": "v1_2_rev1",
-                "1.3-rev0": "v1_3_rev0",
-                "1.3-rev1": "v1_3_rev1",
-            }
+            return dict(FALLBACK_API_VERSIONS)
+
+        # Sort numerically so the selector order does not depend on filesystem ordering
+        versions = {display: module for _, display, module in sorted(discovered)}
 
         _LOGGER.debug("Discovered API versions: %s", list(versions.keys()))
 
     except Exception as err:
         _LOGGER.warning("Failed to discover API versions: %s, using defaults", err)
-        return {
-            "1.2-rev1": "v1_2_rev1",
-            "1.3-rev0": "v1_3_rev0",
-            "1.3-rev1": "v1_3_rev1",
-        }
+        return dict(FALLBACK_API_VERSIONS)
 
     return versions
 
@@ -104,7 +107,7 @@ def check_api_feature_availability(api_version: str, feature_path: str) -> bool:
     Returns:
         bool: True if the feature is available in the API version, False otherwise
     """
-    api_module = API_VERSIONS.get(api_version, "v1_3_rev1")
+    api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
     try:
         # Try to import the module/feature

--- a/custom_components/veeam_br/manifest.json
+++ b/custom_components/veeam_br/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Cenvora/ha-veeam-br/issues",
   "requirements": [
-    "veeam-br>=0.2.0b2,<1.0.0"
+    "veeam-br>=0.3.0,<1.0.0"
   ],
-  "version": "0.4.4b1"
+  "version": "0.5.0b1"
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -209,13 +209,21 @@ def test_reconfigure_flow():
         strings = json.load(f)
 
     assert "reconfigure" in strings["config"]["step"], "strings.json should have reconfigure step"
-    
+
     # Check that abort messages exist for reconfigure and reauth
     assert "abort" in strings["config"], "strings.json should have abort section"
-    assert "reconfigure_successful" in strings["config"]["abort"], "strings.json should have reconfigure_successful abort message"
-    assert "reauth_successful" in strings["config"]["abort"], "strings.json should have reauth_successful abort message"
-    assert "cannot_connect" in strings["config"]["abort"], "strings.json should have cannot_connect abort message"
-    assert "invalid_auth" in strings["config"]["abort"], "strings.json should have invalid_auth abort message"
+    assert (
+        "reconfigure_successful" in strings["config"]["abort"]
+    ), "strings.json should have reconfigure_successful abort message"
+    assert (
+        "reauth_successful" in strings["config"]["abort"]
+    ), "strings.json should have reauth_successful abort message"
+    assert (
+        "cannot_connect" in strings["config"]["abort"]
+    ), "strings.json should have cannot_connect abort message"
+    assert (
+        "invalid_auth" in strings["config"]["abort"]
+    ), "strings.json should have invalid_auth abort message"
     assert "unknown" in strings["config"]["abort"], "strings.json should have unknown abort message"
 
 
@@ -300,34 +308,34 @@ def test_stale_entity_cleanup_uses_registry_scan():
     # entity unique_ids by substring. The new approach must scan the full registry
     # using async_entries_for_config_entry and compare against current API data.
     # Verify the new approach is used instead of the old set-difference pattern.
-    assert "stale_job_ids = current_job_ids - current_jobs_in_data" not in sensor_content, (
-        "sensor.py should not use session-scoped set-difference for stale job detection"
-    )
-    assert "stale_repo_ids = current_repo_ids - current_repos_in_data" not in sensor_content, (
-        "sensor.py should not use session-scoped set-difference for stale repo detection"
-    )
-    assert "stale_sobr_ids = current_sobr_ids - current_sobrs_in_data" not in sensor_content, (
-        "sensor.py should not use session-scoped set-difference for stale SOBR detection"
-    )
-    assert "stale_job_ids = current_job_ids - current_jobs_in_data" not in button_content, (
-        "button.py should not use session-scoped set-difference for stale job detection"
-    )
+    assert (
+        "stale_job_ids = current_job_ids - current_jobs_in_data" not in sensor_content
+    ), "sensor.py should not use session-scoped set-difference for stale job detection"
+    assert (
+        "stale_repo_ids = current_repo_ids - current_repos_in_data" not in sensor_content
+    ), "sensor.py should not use session-scoped set-difference for stale repo detection"
+    assert (
+        "stale_sobr_ids = current_sobr_ids - current_sobrs_in_data" not in sensor_content
+    ), "sensor.py should not use session-scoped set-difference for stale SOBR detection"
+    assert (
+        "stale_job_ids = current_job_ids - current_jobs_in_data" not in button_content
+    ), "button.py should not use session-scoped set-difference for stale job detection"
 
     # Verify that the cleanup uses entity registry scanning
-    assert "async_entries_for_config_entry" in sensor_content, (
-        "sensor.py stale cleanup should scan the entity registry"
-    )
-    assert "async_entries_for_config_entry" in button_content, (
-        "button.py stale cleanup should scan the entity registry"
-    )
+    assert (
+        "async_entries_for_config_entry" in sensor_content
+    ), "sensor.py stale cleanup should scan the entity registry"
+    assert (
+        "async_entries_for_config_entry" in button_content
+    ), "button.py stale cleanup should scan the entity registry"
 
     # Verify that device registry cleanup is present in sensor.py
-    assert "device_registry" in sensor_content or "dr.async_get" in sensor_content, (
-        "sensor.py should clean up orphaned devices from the device registry"
-    )
-    assert "async_remove_device" in sensor_content, (
-        "sensor.py should remove orphaned devices via device_registry.async_remove_device"
-    )
+    assert (
+        "device_registry" in sensor_content or "dr.async_get" in sensor_content
+    ), "sensor.py should clean up orphaned devices from the device registry"
+    assert (
+        "async_remove_device" in sensor_content
+    ), "sensor.py should remove orphaned devices via device_registry.async_remove_device"
 
 
 def test_validate_input_reraises_permission_error():
@@ -348,15 +356,13 @@ def test_validate_input_reraises_permission_error():
 
     # The validate_input function must re-raise PermissionError before the generic
     # Exception handler, so that callers can distinguish auth vs connection errors.
-    assert "except PermissionError:" in content, (
-        "validate_input should catch PermissionError separately"
-    )
+    assert (
+        "except PermissionError:" in content
+    ), "validate_input should catch PermissionError separately"
     # PermissionError handler must contain a bare 'raise' before the generic except Exception
     assert re.search(
         r"except\s+PermissionError\s*:.*?raise.*?except\s+Exception", content, re.DOTALL
-    ), (
-        "validate_input should re-raise PermissionError (not wrap it in ConnectionError)"
-    )
+    ), "validate_input should re-raise PermissionError (not wrap it in ConnectionError)"
 
 
 def test_user_step_preserves_input_on_error():
@@ -376,15 +382,15 @@ def test_user_step_preserves_input_on_error():
         content = f.read()
 
     # Verify that host, port and username are populated from user_input when present
-    assert "host_default" in content, (
-        "async_step_user should compute host_default from user_input to preserve the field"
-    )
-    assert "username_default" in content, (
-        "async_step_user should compute username_default from user_input to preserve the field"
-    )
-    assert "port_default" in content, (
-        "async_step_user should compute port_default from user_input to preserve the field"
-    )
+    assert (
+        "host_default" in content
+    ), "async_step_user should compute host_default from user_input to preserve the field"
+    assert (
+        "username_default" in content
+    ), "async_step_user should compute username_default from user_input to preserve the field"
+    assert (
+        "port_default" in content
+    ), "async_step_user should compute port_default from user_input to preserve the field"
 
     # Password must NOT be preserved (security requirement).
     # Find the async_step_user function body up to the next top-level definition.
@@ -396,9 +402,9 @@ def test_user_step_preserves_input_on_error():
     assert user_step_match, "async_step_user should be present"
     user_step_body = user_step_match.group(0)
 
-    assert "password_default" not in user_step_body, (
-        "async_step_user must NOT define a password_default; password should never be pre-filled"
-    )
+    assert (
+        "password_default" not in user_step_body
+    ), "async_step_user must NOT define a password_default; password should never be pre-filled"
 
 
 def test_hlr_immutability_logic():
@@ -411,13 +417,13 @@ def test_hlr_immutability_logic():
         content = f.read()
 
     # Verify HLR immutability logic is present
-    assert "makeRecentBackupsImmutableDays" in content, (
-        "__init__.py should check makeRecentBackupsImmutableDays for Linux Hardened repos"
-    )
+    assert (
+        "makeRecentBackupsImmutableDays" in content
+    ), "__init__.py should check makeRecentBackupsImmutableDays for Linux Hardened repos"
     # Verify that HLR check is guarded so it doesn't override S3 immutability
-    assert '"is_immutable" not in repo_dict' in content, (
-        "HLR immutability check should only run when S3 immutability was not already found"
-    )
+    assert (
+        '"is_immutable" not in repo_dict' in content
+    ), "HLR immutability check should only run when S3 immutability was not already found"
 
 
 def test_api_v1_2_rev1_jobs_error_handling():
@@ -446,9 +452,9 @@ def test_api_v1_2_rev1_jobs_error_handling():
         content,
         flags=re.DOTALL,
     )
-    assert jobs_error_match is not None, (
-        "__init__.py should catch jobs API parsing errors and log them gracefully"
-    )
+    assert (
+        jobs_error_match is not None
+    ), "__init__.py should catch jobs API parsing errors and log them gracefully"
     jobs_error_block = jobs_error_match.group(1)
 
     # The per-job inner loop must also catch ValueError (e.g. unknown enum values)
@@ -456,9 +462,9 @@ def test_api_v1_2_rev1_jobs_error_handling():
     # Check that all four exception types are present within the jobs outer
     # try/except block, without requiring a specific tuple order.
     for exc_type in ("ValueError", "KeyError", "AttributeError", "TypeError"):
-        assert exc_type in jobs_error_block, (
-            f"__init__.py jobs outer try/except should catch {exc_type}"
-        )
+        assert (
+            exc_type in jobs_error_block
+        ), f"__init__.py jobs outer try/except should catch {exc_type}"
 
 
 def test_api_v1_2_rev1_sobr_extent_status():
@@ -486,4 +492,134 @@ def test_api_v1_2_rev1_sobr_extent_status():
     assert "[s.value for s in extent.status]" not in content, (
         "__init__.py must not iterate directly over extent.status — "
         "that fails when status is a str-subclass enum (v1.2-rev1)"
+    )
+
+
+def _load_const():
+    """Load const.py standalone.
+
+    const.py imports only the standard library, so it can be loaded without Home
+    Assistant installed (unlike the rest of the integration package).
+    """
+    import importlib.util
+    from pathlib import Path
+
+    const_path = Path(__file__).parent.parent / "custom_components" / "veeam_br" / "const.py"
+    spec = importlib.util.spec_from_file_location("veeam_br_const", const_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_api_1_3_rev2_supported():
+    """Test that API version 1.3-rev2 (Veeam B&R 13.1) is supported and is the default."""
+    const = _load_const()
+
+    assert (
+        "1.3-rev2" in const.FALLBACK_API_VERSIONS
+    ), "1.3-rev2 must be in the fallback API version list (Veeam B&R 13.1)"
+    assert const.FALLBACK_API_VERSIONS["1.3-rev2"] == "v1_3_rev2"
+    assert const.DEFAULT_API_VERSION == "1.3-rev2", "Default API version should be the newest"
+    assert const.DEFAULT_API_MODULE == "v1_3_rev2"
+    assert (
+        const.DEFAULT_API_VERSION in const.FALLBACK_API_VERSIONS
+    ), "DEFAULT_API_VERSION must be a known API version"
+
+
+def test_manifest_requires_veeam_br_with_rev2():
+    """Test that the manifest requires a veeam-br release that ships v1_3_rev2."""
+    import json
+    from pathlib import Path
+
+    manifest_path = (
+        Path(__file__).parent.parent / "custom_components" / "veeam_br" / "manifest.json"
+    )
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    requirement = next(r for r in manifest["requirements"] if r.startswith("veeam-br"))
+
+    # v1_3_rev2 first shipped in veeam-br 0.3.0
+    assert (
+        ">=0.3.0" in requirement
+    ), f"veeam-br requirement should be >=0.3.0 for 1.3-rev2 support, got {requirement}"
+
+
+def test_api_versions_discovery_is_sorted(tmp_path, monkeypatch):
+    """Test that discovered API versions are ordered oldest to newest.
+
+    os.listdir order is filesystem-dependent, so the selector order (and the
+    first-option fallback in the config flow) must not rely on it.
+    """
+    const = _load_const()
+
+    # Fake veeam_br package directory, created in an order that is not the sorted order
+    for name in (
+        "v1_3_rev10",
+        "v1_2_rev1",
+        "v1_3_rev2",
+        "v1_10_rev0",
+        "v1_3_rev0",
+        "not_a_version",
+    ):
+        (tmp_path / name).mkdir()
+
+    class FakeSpec:
+        submodule_search_locations = [str(tmp_path)]
+        origin = None
+
+    monkeypatch.setattr(const.importlib.util, "find_spec", lambda name: FakeSpec())
+
+    versions = const._discover_api_versions()
+
+    assert list(versions.keys()) == [
+        "1.2-rev1",
+        "1.3-rev0",
+        "1.3-rev2",
+        "1.3-rev10",
+        "1.10-rev0",
+    ], "API versions should be sorted numerically, and non-version directories ignored"
+
+
+def test_api_versions_discovery_falls_back(monkeypatch):
+    """Test that discovery falls back to the static list when veeam_br is unavailable."""
+    const = _load_const()
+
+    monkeypatch.setattr(const.importlib.util, "find_spec", lambda name: None)
+    assert const._discover_api_versions() == const.FALLBACK_API_VERSIONS
+
+    def boom(name):
+        raise RuntimeError("broken package")
+
+    monkeypatch.setattr(const.importlib.util, "find_spec", boom)
+    assert const._discover_api_versions() == const.FALLBACK_API_VERSIONS
+
+
+def test_fallback_api_versions_cover_library():
+    """Test that the fallback list covers every version the installed veeam-br ships.
+
+    The fallback may list newer revisions than an older installed library provides, but it
+    must never omit one the library supports — otherwise that version is unselectable when
+    package inspection fails.
+    """
+    try:
+        from veeam_br.versions import VERSION_TO_PACKAGE
+    except ImportError:
+        pytest.skip("veeam-br not installed")
+
+    const = _load_const()
+
+    library_versions = {
+        version: package.rsplit(".", 1)[-1] for version, package in VERSION_TO_PACKAGE.items()
+    }
+    missing = {
+        version: module
+        for version, module in library_versions.items()
+        if const.FALLBACK_API_VERSIONS.get(version) != module
+    }
+
+    assert not missing, (
+        f"FALLBACK_API_VERSIONS is missing versions shipped by veeam-br: {missing}. "
+        "It should mirror veeam_br.versions.VERSION_TO_PACKAGE."
     )


### PR DESCRIPTION
Require veeam-br >= 0.3.0, which ships the v1_3_rev2 SDK generated from the VBR 13.1 OpenAPI schema, and make 1.3-rev2 the default API version. Every endpoint and model attribute the coordinator and buttons use exists in rev2 (rev2 only adds JobStateModel.target_name), so no call sites change.

Users on older servers can still select an older revision in the config flow, which validates the connection before creating the entry. Existing entries keep their stored api_version.

Also:
- Collapse the four duplicated hardcoded fallback version maps in const.py into a single FALLBACK_API_VERSIONS constant, so adding a revision is a one-line change, and add DEFAULT_API_MODULE to replace the "v1_3_rev1" module literals scattered across button.py, const.py, and __init__.py.
- Sort discovered API versions numerically; the order came from os.listdir, which decides both the selector order and the config flow's first-option fallback.
- Document the supported VBR/API version matrix in the README.
- Add tests for rev2 support, the manifest requirement floor, discovery ordering, fallback behavior, and fallback coverage of the installed library.