### PR TITLE
Load repositories and license when fields are null (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,11 +266,16 @@ All devices and entities associated with this integration will be removed.
 - **Large Deployments**: Polling 100+ jobs may take several seconds per cycle
 - **Real-time Updates**: Changes reflected every 60 seconds, not immediately
 - **SSL Certificates**: Self-signed certificates require SSL verification to be disabled
-- **Null Timestamps**: Veeam's published API schema declares timestamps such as
-  `lastRun`/`nextRun` as non-nullable, but the server sends `null` for jobs that are
-  *Not scheduled* or have never run. The `veeam-br` models are generated from that schema, so
-  they reject the whole jobs response ([#83](https://github.com/Cenvora/ha-veeam-br/issues/83)).
-  The integration patches the affected models at startup to read a null timestamp as absent.
+- **Null Values**: Veeam's published API schema declares many properties non-nullable that the
+  server nonetheless sends as `null` — `nextRun` for a job that is *Not scheduled*, `hostId` for
+  a repository with no host, `instanceLicenseSummary` when it does not apply. The `veeam-br`
+  models are generated from that schema, so each null rejects the entire response for that
+  endpoint ([#83](https://github.com/Cenvora/ha-veeam-br/issues/83),
+  [#82](https://github.com/Cenvora/ha-veeam-br/issues/82)). The integration patches the models
+  at startup to read such nulls as absent values.
+- **Multiple Servers**: supported, one config entry per server. Devices are named after the
+  server they belong to; if two entries point at the *same* server, their job, repository and
+  SOBR devices are shared, since those device identifiers come from Veeam's own object IDs.
 - **API Version Must Match New Workloads**: the client rejects enum values it does not know, and
   the jobs response is parsed as a whole. If the server returns a job type the selected API
   version predates — a Proxmox VE or Nutanix AHV job on 13.1 read over `1.3-rev1`, for example —

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import timedelta
 import importlib
 import logging
+import sys
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME, Platform
@@ -23,7 +24,7 @@ from .const import (
     DOMAIN,
     UPDATE_INTERVAL,
 )
-from .sdk_patches import patch_models as patch_null_timestamp_models
+from .sdk_patches import patch_models as patch_null_values_in_models
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,22 +50,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Failed to import veeam_br types: %s", err)
         return False
 
-    # Teach the generated models to tolerate null timestamps before anything parses a
-    # response, or one unscheduled job hides every job (issue #83). Imports are blocking,
-    # so patching runs off the event loop.
+    # Teach the generated models to tolerate nulls where Veeam's schema promises a value,
+    # before anything parses a response. Without this a single null timestamp, UUID or
+    # nested object empties a whole endpoint (issues #82 and #83). Importing the models
+    # package blocks, so this runs off the event loop.
     def patch_models() -> int:
-        return patch_null_timestamp_models(
-            lambda name: importlib.import_module(f"veeam_br.{api_module}.models.{name}"),
-            UNSET,
-        )
+        models_package = f"veeam_br.{api_module}.models"
+        importlib.import_module(models_package)  # imports every model module eagerly
+        return patch_null_values_in_models(models_package, UNSET, sys.modules)
 
     try:
         patched = await asyncio.to_thread(patch_models)
-        _LOGGER.debug("Patched %d model modules to tolerate null timestamps", patched)
+        _LOGGER.debug("Patched %d model modules to tolerate null values", patched)
     except Exception as err:  # noqa: BLE001 - never block setup over a resilience patch
         _LOGGER.warning(
-            "Could not patch veeam_br models for null timestamps (%s); jobs with no "
-            "schedule or no previous run may fail to load. See "
+            "Could not patch veeam_br models for null values (%s); jobs, repositories or "
+            "license data may fail to load. See "
             "https://github.com/Cenvora/ha-veeam-br/issues/83",
             err,
         )
@@ -147,6 +148,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     return None
                 return dt_val
 
+            # Helper to safely get UUID as string
+            def get_uuid_value(uuid_val):
+                """Extract UUID value."""
+                if uuid_val is None or uuid_val is UNSET:
+                    return None
+                return str(uuid_val)
+
             # Fetch jobs data — wrapped in try/except so a parsing failure (e.g.
             # an API-version mismatch in the veeam_br library causing a ValueError
             # from dict()) degrades gracefully rather than aborting the whole setup.
@@ -166,8 +174,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     for job in jobs_data:
                         try:
+                            # A null id parses as UNSET (see sdk_patches); entity unique
+                            # IDs are built from it, so skip rather than emit "None" ones
+                            job_id = get_uuid_value(job.id)
+                            if not job_id:
+                                _LOGGER.warning(
+                                    "Skipping job %s: no usable ID",
+                                    getattr(job, "name", "Unknown"),
+                                )
+                                continue
+
                             job_dict = {
-                                "id": str(job.id),
+                                "id": job_id,
                                 "name": job.name or "Unknown",
                                 "type": get_enum_value(job.type_),
                                 "status": get_enum_value(job.status),
@@ -289,13 +307,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Fetch repositories information
             repositories_list = []
             try:
-                # Helper to safely get UUID as string
-                def get_uuid_value(uuid_val):
-                    """Extract UUID value."""
-                    if uuid_val is None or uuid_val is UNSET:
-                        return None
-                    return str(uuid_val)
-
                 # Helper to serialize nested objects to dict
                 def serialize_value(value):
                     """Recursively serialize values to JSON-compatible types."""
@@ -355,6 +366,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     for repo in repositories_data:
                         try:
+                            # See the job loop: entity unique IDs need a usable ID
+                            if not get_uuid_value(repo.id):
+                                _LOGGER.warning(
+                                    "Skipping repository %s: no usable ID",
+                                    getattr(repo, "name", "Unknown"),
+                                )
+                                continue
+
                             repo_dict = {
                                 "id": get_uuid_value(repo.id),
                                 "name": repo.name or "Unknown",
@@ -479,6 +498,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     for sobr in sobr_data:
                         try:
+                            # See the job loop: entity unique IDs need a usable ID
+                            if not get_uuid_value(sobr.id):
+                                _LOGGER.warning(
+                                    "Skipping scale-out repository %s: no usable ID",
+                                    getattr(sobr, "name", "Unknown"),
+                                )
+                                continue
+
                             sobr_dict = {
                                 "id": get_uuid_value(sobr.id),
                                 "name": sobr.name or "Unknown",

--- a/custom_components/veeam_br/config_flow.py
+++ b/custom_components/veeam_br/config_flow.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
+import sys
 from typing import Any
 
 from homeassistant import config_entries
@@ -16,11 +18,13 @@ from .const import (
     API_VERSIONS,
     CONF_API_VERSION,
     CONF_VERIFY_SSL,
+    DEFAULT_API_MODULE,
     DEFAULT_API_VERSION,
     DEFAULT_PORT,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
 )
+from .sdk_patches import patch_models as patch_null_values_in_models
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,12 +48,41 @@ def _get_api_version_selector_config(
     return [DEFAULT_API_VERSION], DEFAULT_API_VERSION
 
 
+def _load_veeam_br(api_version: str):
+    """Import veeam_br and everything connect() imports dynamically, then patch models.
+
+    VeeamClient.connect() resolves the versioned SDK with importlib at call time. Left to
+    itself that lands on the event loop, which Home Assistant reports as a blocking call,
+    so every module it needs is imported here instead — this runs in an executor. Importing
+    a model imports the whole models package, so patching it costs nothing extra.
+    """
+    from veeam_br.client import VeeamClient
+
+    api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
+    package = f"veeam_br.{api_module}"
+
+    for module in (
+        f"{package}.client",
+        f"{package}.api.login.create_token",
+        f"{package}.models.token_login_spec",
+        f"{package}.models.e_login_grant_type",
+    ):
+        importlib.import_module(module)
+
+    models_package = f"{package}.models"
+    patch_null_values_in_models(
+        models_package, importlib.import_module(f"{package}.types").UNSET, sys.modules
+    )
+
+    return VeeamClient
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
     api_version = data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
 
     try:
-        from veeam_br.client import VeeamClient
+        VeeamClient = await hass.async_add_executor_job(_load_veeam_br, api_version)
     except ImportError as err:
         _LOGGER.error("Error importing veeam_br: %s", err)
         raise ConnectionError("Failed to import veeam_br modules") from err

--- a/custom_components/veeam_br/manifest.json
+++ b/custom_components/veeam_br/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Cenvora/ha-veeam-br/issues",
   "requirements": [
-    "veeam-br>=0.3.0,<1.0.0"
+    "veeam-br>=0.3.1,<1.0.0"
   ],
   "version": "0.5.0b1"
 }

--- a/custom_components/veeam_br/sdk_patches.py
+++ b/custom_components/veeam_br/sdk_patches.py
@@ -1,30 +1,42 @@
-"""Runtime patches for the veeam-br generated models.
+"""Runtime patches making the veeam-br generated models tolerate null values.
 
-Only one patch so far: making timestamp parsing tolerate null.
+Veeam's published schema declares many properties non-nullable that the server nonetheless
+sends as ``null``. The generated models reproduce the schema faithfully, so each such null
+raises while parsing — and because a response is parsed as a whole, one null makes the
+entire endpoint's data disappear. Three shapes of this have been reported:
 
-Veeam Backup & Replication sends ``"nextRun": null`` for a job that is *Not scheduled* and
-``"lastRun": null`` for a job that has never run. The OpenAPI schema declares both as
-non-nullable ``date-time`` properties, so the generated model calls ``isoparse(None)`` and
-raises ``TypeError: object of type 'NoneType' has no len()``. Responses are parsed as a
-whole, so a single such job makes *every* job disappear.
+* a null timestamp — ``isoparse(None)`` raises
+  ``TypeError: object of type 'NoneType' has no len()``. VBR sends ``"nextRun": null`` for
+  a job that is *Not scheduled* and ``"lastRun": null`` for one that has never run, so a
+  single unscheduled job hid every job (issue #83).
+* a null UUID — ``UUID(None)`` raises
+  ``TypeError: one of the hex, bytes, bytes_le, fields, or int arguments must be given``.
+  VBR sends ``"hostId": null`` for repositories not bound to a host, so one such
+  repository hid every repository (issue #82).
+* a null nested object — ``SomeModel.from_dict(None)`` raises
+  ``TypeError: 'NoneType' object is not iterable``, because from_dict starts with
+  ``dict(src_dict)``. VBR sends ``"instanceLicenseSummary": null`` when that summary does
+  not apply, which lost all license data (issue #82).
 
-See https://github.com/Cenvora/ha-veeam-br/issues/83. This affects every API version
-(1.2-rev1 through 1.3-rev2), so selecting a different one is not a workaround.
+Each patch maps a null onto ``UNSET``, the sentinel the generated code already uses for an
+absent field: ``to_dict`` skips it and this integration already reads it as None. Nothing
+else changes — a null was previously an exception, never a value, so no payload that parses
+today parses differently afterwards.
 
-The discrepancy is in Veeam's own published schema, which declares these properties
-non-nullable while the server sends null. veeam-br's models are generated from that
-schema, so they faithfully reproduce it; the mismatch has to be absorbed at runtime by
-consumers, which is what this module does.
+Deliberately *not* done: stripping nulls from the payload before parsing. That looks
+simpler but regresses fields that are required and legitimately nullable, such as the four
+progress rates in SessionProgressType0 (nested in JobStateModel), where a null is valid
+input and dropping the key raises KeyError instead.
 
-Each generated model module does ``from dateutil.parser import isoparse`` and calls it by
-that name, so rebinding the name on the module makes the module's own ``from_dict``
-tolerant without touching shared library state — patching ``dateutil`` itself would change
-behavior for every other integration in the process.
+Generated model modules do ``from dateutil.parser import isoparse`` / ``from uuid import
+UUID`` and call them by those names, so rebinding the names per module changes only that
+module's parsing — patching ``dateutil`` or ``uuid`` globally would affect every other
+integration in the process.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Mapping
 import logging
 from types import ModuleType
 from typing import Any
@@ -32,61 +44,97 @@ from typing import Any
 _LOGGER = logging.getLogger(__name__)
 
 # Marker set on a patched module so re-running is free and idempotent
-PATCH_MARKER = "_ha_veeam_br_null_timestamps_patched"
-
-# Model modules whose timestamps this integration reads. Only the modules that actually
-# parse a date-time need patching; add to this list when consuming a new endpoint whose
-# model has an optional timestamp.
-TIMESTAMP_MODEL_MODULES = (
-    # jobs.get_all_jobs_states — lastRun/nextRun, the fields behind issue #83
-    "job_state_model",
-    # license_.get_installed_license — expiration dates, null on licenses that never expire
-    "installed_license_model",
-    "instance_license_summary_model",
-    # login.create_token — token issue/expiry timestamps
-    "token_model",
-)
+PATCH_MARKER = "_ha_veeam_br_null_tolerance_patched"
 
 
-def patch_null_timestamps(module: ModuleType, unset: Any) -> bool:
-    """Make one generated model module tolerate null timestamps.
+def _patch_parsers(module: ModuleType, unset: Any) -> None:
+    """Rebind the module's isoparse/UUID so a null parses as absent."""
+    isoparse = getattr(module, "isoparse", None)
+    if isoparse is not None:
 
-    Rebinds the module's ``isoparse`` so a null parses as ``unset`` — the sentinel the
-    generated code already uses for an absent field, which ``to_dict`` skips and this
-    integration already maps to None. Returns True if the module was patched, False if it
-    was already patched or has no ``isoparse`` to patch.
+        def tolerant_isoparse(value: Any) -> Any:
+            if value is None:
+                return unset
+            return isoparse(value)
+
+        setattr(module, "isoparse", tolerant_isoparse)
+
+    uuid_type = getattr(module, "UUID", None)
+    if uuid_type is not None:
+
+        def tolerant_uuid(value: Any = None, *args: Any, **kwargs: Any) -> Any:
+            if value is None and not args and not kwargs:
+                return unset
+            return uuid_type(value, *args, **kwargs)
+
+        setattr(module, "UUID", tolerant_uuid)
+
+
+def _patch_from_dict(module: ModuleType, unset: Any) -> None:
+    """Make the module's model classes read a null object as absent.
+
+    Only the null case is intercepted; a real payload goes to the generated from_dict
+    untouched.
     """
-    original = getattr(module, "isoparse", None)
-    if original is None or getattr(module, PATCH_MARKER, False):
+    for attribute in list(vars(module).values()):
+        if not isinstance(attribute, type) or attribute.__module__ != module.__name__:
+            continue
+
+        from_dict = getattr(attribute, "from_dict", None)
+        original = getattr(from_dict, "__func__", None)
+        if original is None:
+            continue
+
+        def tolerant_from_dict(cls: type, src_dict: Any, _original=original) -> Any:
+            if src_dict is None:
+                return unset
+            return _original(cls, src_dict)
+
+        attribute.from_dict = classmethod(tolerant_from_dict)
+
+
+def patch_null_values(module: ModuleType, unset: Any) -> bool:
+    """Make one generated model module tolerate nulls where the schema promises a value.
+
+    Returns True if the module was patched, False if it was already patched or holds
+    nothing to patch.
+    """
+    if getattr(module, PATCH_MARKER, False):
         return False
 
-    def isoparse(value: Any) -> Any:
-        """Parse a timestamp, treating null as an absent value rather than an error."""
-        if value is None:
-            return unset
-        return original(value)
+    has_parsers = hasattr(module, "isoparse") or hasattr(module, "UUID")
+    has_models = any(
+        isinstance(attribute, type)
+        and attribute.__module__ == module.__name__
+        and hasattr(attribute, "from_dict")
+        for attribute in vars(module).values()
+    )
+    if not has_parsers and not has_models:
+        return False
 
-    setattr(module, "isoparse", isoparse)
+    _patch_parsers(module, unset)
+    _patch_from_dict(module, unset)
     setattr(module, PATCH_MARKER, True)
     return True
 
 
-def patch_models(import_module: Callable[[str], ModuleType], unset: Any) -> int:
-    """Patch every model module in TIMESTAMP_MODEL_MODULES that exists.
+def patch_models(models_package: str, unset: Any, modules: Mapping[str, ModuleType]) -> int:
+    """Patch every already-imported model module of one API version.
 
-    ``import_module`` is injected (rather than calling importlib here) so the caller can
-    run the blocking imports off the event loop. Missing modules are skipped, since which
-    models exist varies by API version.
+    ``modules`` is normally sys.modules, injected so this stays testable. Importing the
+    models package imports all of its modules eagerly, so the caller only has to import
+    the package itself first — every model is then reachable here.
     """
+    prefix = f"{models_package}."
     patched = 0
-    for name in TIMESTAMP_MODEL_MODULES:
-        try:
-            module = import_module(name)
-        except ImportError:
-            _LOGGER.debug("Model module %s not present in this API version", name)
-            continue
 
-        if patch_null_timestamps(module, unset):
-            patched += 1
+    for name, module in list(modules.items()):
+        if not name.startswith(prefix) or module is None:
+            continue
+        try:
+            if patch_null_values(module, unset):
+                patched += 1
+        except Exception as err:  # noqa: BLE001 - one odd module must not stop the rest
+            _LOGGER.debug("Could not patch %s: %s", name, err)
 
     return patched

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import CONF_HOST, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -299,7 +299,9 @@ class VeeamLicenseMixin:
         """Return device info for the Veeam license."""
         return {
             "identifiers": {(DOMAIN, f"license_{self._config_entry.entry_id}")},
-            "name": "Veeam License",
+            # Qualified by host: a hardcoded name is indistinguishable once a second
+            # server is added (issue #82)
+            "name": f"Veeam License ({self._config_entry.data.get(CONF_HOST, 'Unknown')})",
             "manufacturer": "Veeam",
             "model": "License",
         }
@@ -509,7 +511,10 @@ class VeeamServerBaseSensor(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return device info for the Veeam server."""
         server_info = self._server_info()
-        server_name = server_info.get("name", "Unknown") if server_info else "Unknown"
+        # Fall back to the configured host rather than a bare "Unknown": when server info
+        # fails to fetch, every entry's device would otherwise carry the same name (#82)
+        host = self._config_entry.data.get(CONF_HOST, "Unknown")
+        server_name = (server_info.get("name") if server_info else None) or host
         return {
             "identifiers": {(DOMAIN, f"server_{self._config_entry.entry_id}")},
             "name": f"{server_name}",
@@ -670,7 +675,10 @@ class VeeamServerBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
     def device_info(self):
         """Return device info for the Veeam server."""
         server_info = self._server_info()
-        server_name = server_info.get("name", "Unknown") if server_info else "Unknown"
+        # Fall back to the configured host rather than a bare "Unknown": when server info
+        # fails to fetch, every entry's device would otherwise carry the same name (#82)
+        host = self._config_entry.data.get(CONF_HOST, "Unknown")
+        server_name = (server_info.get("name") if server_info else None) or host
         return {
             "identifiers": {(DOMAIN, f"server_{self._config_entry.entry_id}")},
             "name": f"{server_name}",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -615,10 +615,11 @@ def test_api_1_3_rev2_supported():
     ), "DEFAULT_API_VERSION must be a known API version"
 
 
-def test_manifest_requires_veeam_br_with_rev2():
-    """Test that the manifest requires a veeam-br release that ships v1_3_rev2."""
+def test_manifest_requires_a_recent_enough_veeam_br():
+    """Test that the manifest's veeam-br floor covers what the integration relies on."""
     import json
     from pathlib import Path
+    import re
 
     manifest_path = (
         Path(__file__).parent.parent / "custom_components" / "veeam_br" / "manifest.json"
@@ -629,10 +630,20 @@ def test_manifest_requires_veeam_br_with_rev2():
 
     requirement = next(r for r in manifest["requirements"] if r.startswith("veeam-br"))
 
-    # v1_3_rev2 first shipped in veeam-br 0.3.0
-    assert (
-        ">=0.3.0" in requirement
-    ), f"veeam-br requirement should be >=0.3.0 for 1.3-rev2 support, got {requirement}"
+    # Floors we depend on, newest first:
+    #   0.3.1 — VeeamClient recovers from a refused token refresh instead of leaving a
+    #           dead session behind (issue #82)
+    #   0.3.0 — first release shipping the v1_3_rev2 SDK
+    minimum = (0, 3, 1)
+
+    match = re.search(r">=\s*(\d+)\.(\d+)\.(\d+)", requirement)
+    assert match, f"veeam-br requirement should pin a minimum version, got {requirement}"
+
+    floor = tuple(int(part) for part in match.groups())
+    assert floor >= minimum, (
+        f"veeam-br requirement floor {'.'.join(map(str, floor))} is below the "
+        f"{'.'.join(map(str, minimum))} that this integration relies on"
+    )
 
 
 def test_api_versions_discovery_is_sorted(tmp_path, monkeypatch):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -495,12 +495,12 @@ def test_api_v1_2_rev1_sobr_extent_status():
     )
 
 
-def test_null_timestamp_patch_is_applied_before_any_request():
-    """Test that the null-timestamp patch is applied during setup (issue #83).
+def test_null_value_patch_is_applied_before_any_request():
+    """Test that the null-tolerance patch is applied during setup (issues #82, #83).
 
-    VBR sends nextRun=null for an unscheduled job, which makes the generated model reject
-    the whole jobs response. The patch must land before the first API call, or the first
-    refresh still loses every job. (The patch itself is tested in test_sdk_patches.py.)
+    VBR sends nulls where the schema promises values, which makes the generated models
+    reject the whole response. The patch must land before the first API call, or the first
+    refresh still loses the data. (The patch itself is tested in test_sdk_patches.py.)
     """
     from pathlib import Path
 
@@ -513,7 +513,7 @@ def test_null_timestamp_patch_is_applied_before_any_request():
         "from .sdk_patches import" in content
     ), "__init__.py should apply the model patches from sdk_patches"
 
-    patch_call = content.index("patch_null_timestamp_models(")
+    patch_call = content.index("patch_null_values_in_models(")
     connect_call = content.index("await veeam_client.connect()")
     assert patch_call < connect_call, (
         "models must be patched before the client connects, so no response is parsed by "
@@ -524,6 +524,64 @@ def test_null_timestamp_patch_is_applied_before_any_request():
     assert (
         "await asyncio.to_thread(patch_models)" in content
     ), "model patching does blocking imports and should run via asyncio.to_thread"
+
+
+def test_config_flow_does_not_import_on_the_event_loop():
+    """Test that the config flow pre-imports the SDK off the loop (issue #82).
+
+    VeeamClient.connect() resolves the versioned SDK with importlib at call time, which
+    Home Assistant reports as a blocking call when awaited directly from the flow.
+    """
+    from pathlib import Path
+
+    config_flow_path = (
+        Path(__file__).parent.parent / "custom_components" / "veeam_br" / "config_flow.py"
+    )
+
+    with open(config_flow_path) as f:
+        content = f.read()
+
+    assert (
+        "async_add_executor_job(_load_veeam_br" in content
+    ), "veeam_br should be imported in an executor, not on the event loop"
+
+    # Everything connect() imports dynamically must be pre-imported there
+    loader = content[
+        content.index("def _load_veeam_br") : content.index("async def validate_input")
+    ]
+    for module in ("client", "api.login.create_token", "models.token_login_spec"):
+        assert module in loader, f"_load_veeam_br should pre-import {module}"
+
+    # The plain import must not sit in the coroutine any more
+    validate = content[content.index("async def validate_input") :]
+    validate = validate[: validate.index("\nclass ")]
+    assert (
+        "from veeam_br.client import VeeamClient" not in validate
+    ), "importing veeam_br inside validate_input puts a blocking import on the loop"
+
+
+def test_devices_are_distinguishable_across_servers():
+    """Test that device names identify their server (issue #82).
+
+    With two entries configured, a hardcoded or "Unknown" device name appears twice and
+    the user cannot tell the servers apart.
+    """
+    from pathlib import Path
+
+    sensor_path = Path(__file__).parent.parent / "custom_components" / "veeam_br" / "sensor.py"
+
+    with open(sensor_path) as f:
+        content = f.read()
+
+    assert (
+        '"name": "Veeam License"' not in content
+    ), "the license device name must be qualified per entry, not hardcoded"
+    assert (
+        'server_info.get("name", "Unknown") if server_info else "Unknown"' not in content
+    ), "the server device should fall back to the configured host, not a shared 'Unknown'"
+    assert (
+        content.count("Veeam License (") == 1
+    ), "the license device name should include the configured host"
 
 
 def _load_const():

--- a/tests/test_sdk_patches.py
+++ b/tests/test_sdk_patches.py
@@ -1,4 +1,4 @@
-"""Tests for the null-timestamp model patch (issue #83).
+"""Tests for the null-tolerance model patches (issues #82 and #83).
 
 These run against the real installed veeam-br models, so they verify the patch actually
 fixes the reported failure rather than just that the code is present. sdk_patches imports
@@ -86,7 +86,7 @@ def test_null_timestamp_fails_before_patch_and_parses_after(package, null_field)
     with pytest.raises(TypeError, match="object of type 'NoneType' has no len"):
         module.JobStateModel.from_dict(payload)
 
-    assert sdk_patches.patch_null_timestamps(module, unset) is True
+    assert sdk_patches.patch_null_values(module, unset) is True
 
     job = module.JobStateModel.from_dict(payload)
     field = "next_run" if null_field == "nextRun" else "last_run"
@@ -116,7 +116,7 @@ def test_whole_response_survives_one_unscheduled_job(package):
 
     # JobStatesResult delegates to JobStateModel, so patch the module it actually uses
     results_module = importlib.import_module(f"{package}.models.job_states_result")
-    sdk_patches.patch_null_timestamps(
+    sdk_patches.patch_null_values(
         importlib.import_module(f"{package}.models.job_state_model"), unset
     )
 
@@ -139,7 +139,7 @@ def test_valid_timestamps_are_untouched():
 
     module = _fresh_model_module(package, "job_state_model")
     before = module.JobStateModel.from_dict(job_payload(package, module))
-    sdk_patches.patch_null_timestamps(module, unset)
+    sdk_patches.patch_null_values(module, unset)
     after = module.JobStateModel.from_dict(job_payload(package, module))
 
     assert before.last_run == after.last_run
@@ -153,61 +153,150 @@ def test_patch_is_idempotent():
     unset = importlib.import_module(f"{package}.types").UNSET
 
     module = _fresh_model_module(package, "job_state_model")
-    assert sdk_patches.patch_null_timestamps(module, unset) is True
+    assert sdk_patches.patch_null_values(module, unset) is True
     patched_isoparse = module.isoparse
 
-    assert sdk_patches.patch_null_timestamps(module, unset) is False
+    assert sdk_patches.patch_null_values(module, unset) is False
     assert module.isoparse is patched_isoparse
 
 
-def test_module_without_isoparse_is_skipped():
-    """Patching a module that parses no timestamps should report no work done."""
+def test_module_with_nothing_to_patch_is_skipped():
+    """A module that parses nothing should report no work done."""
     sdk_patches = _load_sdk_patches()
 
-    assert sdk_patches.patch_null_timestamps(ModuleType("no_timestamps"), object()) is False
+    assert sdk_patches.patch_null_values(ModuleType("nothing_to_patch"), object()) is False
 
 
-def test_patch_models_reports_count_and_skips_missing():
-    """patch_models should patch what exists and ignore what does not."""
+# ---------------------------------------------------------------------------
+# Null UUID — VBR sends "hostId": null for repositories with no host (#82)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("package", sorted(set(veeam_br_versions.values())))
+def test_null_uuid_fails_before_patch_and_parses_after(package):
+    """The repositories error from issue #82, on the model that parses `hostId`.
+
+    Asserted at the module's UUID binding rather than through a full RepositoryStateModel
+    payload, since which fields that model requires varies by API version.
+    """
+    sdk_patches = _load_sdk_patches()
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    module = _fresh_model_module(package, "repository_state_model")
+    assert "host_id" in {
+        field.name for field in module.RepositoryStateModel.__attrs_attrs__
+    }, "this model should be the one carrying the optional hostId"
+
+    with pytest.raises(TypeError, match="hex, bytes, bytes_le, fields, or int"):
+        module.UUID(None)
+
+    assert sdk_patches.patch_null_values(module, unset) is True
+
+    assert module.UUID(None) is unset, "a null UUID should read as the absent sentinel"
+    real = "6f1f0f8a-0000-4000-8000-000000000001"
+    assert str(module.UUID(real)) == real, "real UUIDs must still parse"
+
+
+# ---------------------------------------------------------------------------
+# Null nested object — VBR sends "instanceLicenseSummary": null (#82)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("package", sorted(set(veeam_br_versions.values())))
+def test_null_nested_object_fails_before_patch_and_parses_after(package):
+    """The license error from issue #82: from_dict starts with dict(src_dict)."""
+    sdk_patches = _load_sdk_patches()
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    module = _fresh_model_module(package, "instance_license_summary_model")
+    model = module.InstanceLicenseSummaryModel
+
+    with pytest.raises(TypeError, match="'NoneType' object is not iterable"):
+        model.from_dict(None)
+
+    assert sdk_patches.patch_null_values(module, unset) is True
+
+    assert model.from_dict(None) is unset, "a null nested object should read as absent"
+
+
+def test_required_nullable_fields_still_parse():
+    """Guard against 'just strip the nulls', which would break these.
+
+    SessionProgressType0 (nested in JobStateModel) has four fields that are required and
+    legitimately nullable, so a null is valid input there and dropping the key would raise
+    KeyError. The patches must leave that working.
+    """
     sdk_patches = _load_sdk_patches()
     package = sorted(set(veeam_br_versions.values()))[0]
     unset = importlib.import_module(f"{package}.types").UNSET
 
-    loaded = {}
+    module = _fresh_model_module(package, "session_progress_type_0")
+    bottleneck = list(
+        importlib.import_module(
+            f"{package}.models.e_session_bottleneck_type"
+        ).ESessionBottleneckType
+    )[0]
+    progress = module.SessionProgressType0(
+        duration="00:10:00",
+        processing_rate=None,
+        bottleneck=bottleneck,
+        processed_size=None,
+        read_size=None,
+        transferred_size=None,
+    )
+    payload = progress.to_dict()
+    assert payload["processingRate"] is None, "the fixture should carry the valid nulls"
 
-    def import_module(name):
-        if name == "definitely_not_a_model":
-            raise ImportError(name)
-        module = _fresh_model_module(package, name)
-        loaded[name] = module
-        return module
+    before = module.SessionProgressType0.from_dict(dict(payload))
+    assert sdk_patches.patch_null_values(module, unset) is True
+    after = module.SessionProgressType0.from_dict(dict(payload))
 
-    patched = sdk_patches.patch_models(import_module, unset)
-
-    assert patched == len(loaded), "every importable listed module should be patched"
-    assert patched > 0
-    assert all(getattr(m, sdk_patches.PATCH_MARKER, False) for m in loaded.values())
-
-    # A module that cannot be imported must not fail the whole run
-    sdk_patches.TIMESTAMP_MODEL_MODULES = ("definitely_not_a_model",)
-    assert sdk_patches.patch_models(import_module, unset) == 0
+    for field in ("duration", "processing_rate", "processed_size", "read_size"):
+        assert getattr(after, field) == getattr(before, field), f"{field} changed"
+    assert after.processing_rate is None, "a required nullable field must stay None"
 
 
-def test_listed_modules_exist_and_parse_timestamps():
-    """Every listed module should exist in some version and actually use isoparse.
+# ---------------------------------------------------------------------------
+# patch_models over a whole API version
+# ---------------------------------------------------------------------------
 
-    A typo would otherwise sit here silently doing nothing.
-    """
+
+@pytest.mark.parametrize("package", sorted(set(veeam_br_versions.values())))
+def test_patch_models_covers_the_whole_models_package(package):
+    """Importing the package imports every model, so all of them get patched."""
+    sdk_patches = _load_sdk_patches()
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    models_package = f"{package}.models"
+    importlib.import_module(models_package)
+    modules = {
+        name: module
+        for name, module in list(__import__("sys").modules.items())
+        if name.startswith(f"{models_package}.")
+    }
+
+    patched = sdk_patches.patch_models(models_package, unset, modules)
+
+    assert patched > 100, f"expected the full models package, patched only {patched}"
+
+    # Re-running is idempotent
+    assert sdk_patches.patch_models(models_package, unset, modules) == 0
+
+
+def test_patch_models_ignores_other_packages_and_none_entries():
+    """Only the requested version's models are touched, and stale None entries are safe."""
     sdk_patches = _load_sdk_patches()
 
-    for name in sdk_patches.TIMESTAMP_MODEL_MODULES:
-        found = []
-        for package in sorted(set(veeam_br_versions.values())):
-            spec = importlib.util.find_spec(f"{package}.models.{name}")
-            if spec is None:
-                continue
-            module = importlib.import_module(f"{package}.models.{name}")
-            found.append(hasattr(module, "isoparse"))
+    other = ModuleType("some.other.models.thing")
+    other.isoparse = lambda value: value
+    modules = {
+        "wanted.models.a": ModuleType("wanted.models.a"),
+        "some.other.models.thing": other,
+        "wanted.models.stale": None,
+    }
+    modules["wanted.models.a"].isoparse = lambda value: value
 
-        assert found, f"{name} exists in no installed API version"
-        assert any(found), f"{name} never parses a timestamp, so patching it does nothing"
+    patched = sdk_patches.patch_models("wanted.models", object(), modules)
+
+    assert patched == 1
+    assert not getattr(other, sdk_patches.PATCH_MARKER, False), "other packages untouched"


### PR DESCRIPTION
Closes #82. Requires veeam-br 0.3.1 (released).

## Root cause

Three parse failures, all one defect — Veeam's schema declares a property non-nullable, the
server sends `null` anyway, and the whole response for that endpoint is lost:

| Payload | Raises | Cost |
| --- | --- | --- |
| `"nextRun": null` | `object of type 'NoneType' has no len()` | every job (fixed in #83) |
| `"hostId": null` | `one of the hex, bytes, bytes_le, fields, or int arguments must be given` | every repository |
| `"instanceLicenseSummary": null` | `'NoneType' object is not iterable` | all license data |

`hostId` is optional on `RepositoryStateModel` and null for repositories with no host; the
third is `from_dict` starting with `dict(src_dict)`.

## Fix

Generalizes `sdk_patches` from timestamps to all three shapes, each null mapping to
`UNSET`, applied across the whole models package for the configured API version rather than
a hand-listed subset — #82 is what happens when one model is not on the list. Importing any
model already imports the package eagerly, so full coverage costs nothing extra (817
modules patched on 1.2-rev1).

**Deliberately not "strip nulls before parsing."** That looks simpler but breaks fields that
are required *and* legitimately nullable: `SessionProgressType0`, nested in
`JobStateModel`, has four progress rates where null is valid input and dropping the key
raises `KeyError`. There is a test pinning that behaviour.

Also from the same report:

- **Blocking imports** — `validate_input` pre-imports the SDK in an executor. HA flagged
  `connect()`'s `importlib` calls on the event loop and asked for a bug report.
- **Device naming**, the issue's literal complaint — the license device was hardcoded
  `"Veeam License"` and the server device fell back to a shared `"Unknown"` when server info
  failed, so a second server produced indistinguishable devices. Both now carry the server.
- **Missing IDs** — jobs/repos/SOBRs with no usable ID are skipped instead of generating
  `None`-based unique IDs, now that a null id parses as `UNSET`.
- **veeam-br floor** raised to 0.3.1 for the token-refresh fix, which is the other half of
  the report: every endpoint failing with `Expecting value: line 1 column 1 (char 0)` once
  the token expired. The floor test now parses the pinned version instead of matching a
  literal.

## Verification

End-to-end against the real SDK over `httpx.MockTransport`: both reported payloads raise
their exact errors before the patch and parse cleanly after. Unit tests assert the same per
API version. 49 tests pass; black and isort clean.

## Still open

Why the server's Windows UI language mattered — switching the second server to English made
repositories load. `hostId: null` is not locale-dependent, so this fix makes that endpoint
resilient either way, but raw `/repositories` JSON from a non-English server would confirm
whether localized enum values are a fourth failure mode.
