### PR TITLE
Add High Availability cluster support (VBR 13.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project is an independent, open source project. It is not affiliated with, 
 - 🔄 **Automatic Updates**: Polls the Veeam server every 60 seconds
 - 🎨 **Dynamic Icons**: Visual indicators based on job status (success, running, failed, warning)
 - 📱 **Rich Attributes**: Detailed information including last run, next run, and job type
+- 🔀 **High Availability**: Monitor a clustered server and automate switchover or failover
 
 ## Requirements
 
@@ -154,6 +155,64 @@ The integration also creates devices for:
 - **Scale-Out Backup Repositories (SOBRs)**: Each SOBR device has sensors for description, extent count, and buttons for each extent to enable/disable sealed mode and maintenance mode.
 - **Server**: Server device has sensors for build version, platform, database info, etc.
 - **License**: License device has sensors for status, edition, expiration dates, etc.
+- **High Availability Cluster**: on a clustered Veeam B&R 13.1 server (API `1.3-rev2`), a
+  cluster device with online and failover-in-progress sensors, cluster endpoint and last-online
+  diagnostics, per-node replication state, Patroni role and replication lag, plus switchover
+  and failover buttons. See [High Availability](#high-availability) below.
+
+## High Availability
+
+Veeam B&R 13.1 exposes its High Availability cluster over the REST API. Select the
+`1.3-rev2` API version and, if the server is clustered, a **High Availability Cluster**
+device appears. Servers that are not clustered get no cluster device and no extra polling.
+
+### Entities
+
+| Entity | Notes |
+| ------ | ----- |
+| Online | Connectivity of the cluster as a whole |
+| Failover In Progress | Use this to gate automations, not just to observe |
+| Maintenance In Progress | Diagnostic |
+| Last Online | Diagnostic timestamp |
+| Cluster Endpoint | Diagnostic; DNS name, cross-subnet mode and endpoint migration as attributes |
+| Primary / Secondary Node State | Patroni state, e.g. `Running`, `Streaming`, `Crashed` |
+| Primary / Secondary Node Role | `Leader`, `Replica`, `StandbyLeader`, `SyncStandby` |
+| Primary / Secondary Node Lag | Replication lag in MB |
+
+### Switchover vs failover
+
+- **Switchover** is the planned, graceful role swap. It is the operation to automate, and it
+  keeps Veeam's replication-lag check in force, so the server refuses to promote a badly
+  lagging secondary.
+- **Failover** promotes the secondary without waiting for the primary. It is for when the
+  primary is already gone.
+
+Home Assistant buttons fire immediately with no confirmation step, so the **Failover** entity
+is **disabled by default** — enable it deliberately if you intend to automate it. Both buttons
+report unavailable while a failover or endpoint migration is already running.
+
+> [!WARNING]
+> Both operations move the active role of your backup infrastructure. Treat these buttons as
+> you would a power switch on the server itself, and prefer triggering switchover from an
+> automation with its own conditions over exposing the button on a dashboard.
+
+### Example: alert on an unplanned failover
+
+```yaml
+automation:
+  - alias: "Veeam HA failover started"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.vbr_ha_example_com_failover_in_progress
+        to: "on"
+    action:
+      - service: notify.notify
+        data:
+          title: "Veeam HA failover in progress"
+          message: >
+            Secondary node lag was
+            {{ states('sensor.vbr_ha_example_com_secondary_node_lag') }} MB.
+```
 
 ## Example Automations
 
@@ -294,6 +353,8 @@ The integration monitors the following Veeam objects:
 - ✅ **Scale-Out Repositories** - SOBR and extents
 - ✅ **Server Information** - Veeam server details
 - ✅ **License Information** - License status and expiration
+- ✅ **High Availability Cluster** - cluster state, node roles and replication lag, with
+  switchover and failover actions (Veeam B&R 13.1 and the `1.3-rev2` API version)
 
 ### Supported Entities
 

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+from datetime import timedelta, timezone
 import importlib
 import logging
 import sys
@@ -23,12 +23,105 @@ from .const import (
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     UPDATE_INTERVAL,
+    check_api_feature_availability,
 )
 from .sdk_patches import patch_models as patch_null_values_in_models
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]
+
+# High Availability cluster endpoints exist only from API 1.3-rev2 (VBR 13.1)
+HA_CLUSTER_FEATURE = "api.high_availability_ha_cluster"
+
+
+def _bool_or_none(obj, name: str) -> bool | None:
+    """Read a boolean off a model, mapping UNSET and anything unexpected to None."""
+    value = getattr(obj, name, None)
+    return value if isinstance(value, bool) else None
+
+
+def _parse_ha_cluster_node(node, get_enum_value, get_uuid_value) -> dict | None:
+    """Flatten one HA cluster node into coordinator data."""
+    if not node or not hasattr(node, "name"):
+        return None
+
+    external_endpoint = getattr(node, "external_endpoint", None)
+    if not isinstance(external_endpoint, str):
+        external_endpoint = None
+
+    lag_mb = getattr(node, "lag_mb", None)
+
+    return {
+        "id": get_uuid_value(getattr(node, "id", None)),
+        "name": getattr(node, "name", None) or "Unknown",
+        "ip_address": getattr(node, "ip_address", None) or None,
+        "fqdn": getattr(node, "fqdn", None) or None,
+        "role": get_enum_value(getattr(node, "role", None)),
+        "state": get_enum_value(getattr(node, "state", None)),
+        "timeline": getattr(node, "timeline", None) or None,
+        "lag_mb": lag_mb if isinstance(lag_mb, (int, float)) else None,
+        "external_endpoint": external_endpoint,
+    }
+
+
+def _parse_ha_cluster_last_online(raw_value):
+    """Parse lastOnlineTimeUtc, which Veeam's schema types as a plain string.
+
+    Timestamp sensors need an aware datetime, and the field is documented as UTC, so a
+    value carrying no offset is stamped UTC rather than assumed local.
+    """
+    if not isinstance(raw_value, str) or not raw_value:
+        return None
+
+    parsed = dt_util.parse_datetime(raw_value)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _parse_ha_cluster(cluster, get_enum_value, get_uuid_value, serialize_value) -> dict:
+    """Flatten the HA cluster configuration and its state into coordinator data."""
+    states = getattr(cluster, "states", None)
+
+    def state_flag(name: str) -> bool | None:
+        # states itself is optional in the schema
+        return _bool_or_none(states, name) if states else None
+
+    parsed = {
+        "id": get_uuid_value(getattr(cluster, "id", None)),
+        "name": getattr(cluster, "name", None) or "HA Cluster",
+        "cluster_endpoint": getattr(cluster, "cluster_endpoint", None) or None,
+        "cluster_dns_name": getattr(cluster, "cluster_dns_name", None) or None,
+        "is_cross_subnet_mode": _bool_or_none(cluster, "is_cross_subnet_mode"),
+        "is_online": state_flag("is_online"),
+        "is_failover_in_progress": state_flag("is_failover_in_progress"),
+        "is_maintenance_in_progress": state_flag("is_maintenance_in_progress"),
+        "is_creation_in_progress": state_flag("is_creation_in_progress"),
+        "is_removal_in_progress": state_flag("is_removal_in_progress"),
+        "is_secondary_reinit_in_progress": state_flag("is_secondary_reinit_in_progress"),
+        "is_first_launch_after_failover": state_flag("is_first_launch_after_failover"),
+        "is_endpoint_migration_in_progress": state_flag(
+            "is_cluster_endpoint_migration_in_progress"
+        ),
+        "last_online_time": _parse_ha_cluster_last_online(
+            getattr(states, "last_online_time_utc", None) if states else None
+        ),
+        "primary": _parse_ha_cluster_node(
+            getattr(cluster, "primary_node", None), get_enum_value, get_uuid_value
+        ),
+        "secondary": _parse_ha_cluster_node(
+            getattr(cluster, "secondary_node", None), get_enum_value, get_uuid_value
+        ),
+    }
+
+    # Anything Veeam adds later still reaches the diagnostics download
+    for key, value in getattr(cluster, "additional_properties", {}).items():
+        parsed.setdefault(key, serialize_value(value))
+
+    return parsed
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -101,6 +194,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Pre-import API endpoint modules to avoid blocking calls in event loop
     # The veeam_br library dynamically imports these modules during API calls
+    # High Availability arrived in 1.3-rev2; on older versions the endpoints are not in the
+    # SDK at all, so skip the call rather than fail it on every poll
+    ha_cluster_supported = check_api_feature_availability(api_version, HA_CLUSTER_FEATURE)
+    _LOGGER.debug("HA cluster endpoints available on %s: %s", api_version, ha_cluster_supported)
+
     api_endpoints = [
         "jobs.get_all_jobs_states",
         "service.get_server_info",
@@ -109,6 +207,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "repositories.get_all_repositories_states",
         "repositories.get_all_scale_out_repositories",
     ]
+    if ha_cluster_supported:
+        api_endpoints.append("high_availability_ha_cluster.get_high_availability_cluster")
     for endpoint in api_endpoints:
         try:
             await asyncio.to_thread(
@@ -572,6 +672,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             _LOGGER.debug("Total SOBRs added to coordinator data: %d", len(sobr_list))
 
+            # Fetch High Availability cluster configuration and state. Only reachable on
+            # 1.3-rev2 and newer, and only answered by a server that is actually clustered —
+            # an unclustered server is the common case, not an error.
+            ha_cluster = None
+            if ha_cluster_supported:
+                try:
+                    ha_api = await asyncio.to_thread(
+                        veeam_client.api, "high_availability_ha_cluster"
+                    )
+                    cluster = await veeam_client.call(ha_api.get_high_availability_cluster)
+
+                    if cluster is None or not hasattr(cluster, "cluster_endpoint"):
+                        # None, or an Error model: this server is not clustered
+                        _LOGGER.debug(
+                            "No HA cluster reported by this server (%s)",
+                            type(cluster).__name__,
+                        )
+                    else:
+                        ha_cluster = _parse_ha_cluster(
+                            cluster, get_enum_value, get_uuid_value, serialize_value
+                        )
+                        _LOGGER.debug(
+                            "Parsed HA cluster %s (online=%s)",
+                            ha_cluster.get("name"),
+                            ha_cluster.get("is_online"),
+                        )
+                except (AttributeError, KeyError, TypeError, ValueError) as err:
+                    _LOGGER.warning("Failed to parse HA cluster: %s", err)
+                except Exception as err:
+                    _LOGGER.warning("Failed to fetch HA cluster: %s", err)
+
             # Update diagnostic values - successful poll
             health_ok = True
             last_successful_poll = dt_util.now()
@@ -582,6 +713,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "license_info": license_info,
                 "repositories": repositories_list,
                 "sobrs": sobr_list,
+                "ha_cluster": ha_cluster,
                 "diagnostics": {
                     "connected": connected,
                     "health_ok": health_ok,

--- a/custom_components/veeam_br/button.py
+++ b/custom_components/veeam_br/button.py
@@ -8,7 +8,7 @@ import logging
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import CONF_HOST, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -71,9 +71,12 @@ async def async_setup_entry(
     added_repository_ids: set[str] = set()
     added_sobr_extent_ids: set[tuple[str, str]] = set()  # (sobr_id, extent_id) tuples
     added_job_ids: set[str] = set()
+    ha_cluster_added = False
 
     @callback
     def _sync_entities() -> None:
+        nonlocal ha_cluster_added
+
         if not coordinator.data:
             return
 
@@ -175,6 +178,21 @@ async def async_setup_entry(
                         sobr_id,
                         extent_id,
                     )
+
+        # ---- HA CLUSTER BUTTONS (once) - clustered servers on 1.3-rev2 and newer ----
+        if (
+            not ha_cluster_added
+            and coordinator.data.get("ha_cluster")
+            and check_api_feature_availability(api_version, "api.high_availability_ha_cluster")
+        ):
+            new_entities.extend(
+                [
+                    VeeamHAClusterSwitchoverButton(coordinator, entry, veeam_client),
+                    VeeamHAClusterFailoverButton(coordinator, entry, veeam_client),
+                ]
+            )
+            ha_cluster_added = True
+            _LOGGER.debug("Adding HA cluster buttons")
 
         if new_entities:
             _LOGGER.debug("Adding %d Veeam buttons", len(new_entities))
@@ -957,4 +975,145 @@ class VeeamJobDisableButton(VeeamJobButtonBase):
                 self._job_name,
                 call_err,
             )
+            raise
+
+
+# ===========================
+# HIGH AVAILABILITY CLUSTER BUTTONS
+#
+# Switchover is the planned, graceful role swap; failover is the unplanned one for when the
+# primary is already gone. Both are disruptive, and Home Assistant buttons fire with no
+# confirmation step, so failover is disabled by default — a user automating it has to enable
+# the entity deliberately. See the README for the distinction.
+# ===========================
+
+
+class VeeamHAClusterButtonBase(CoordinatorEntity, ButtonEntity):
+    """Base class for HA cluster buttons."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry, veeam_client):
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._veeam_client = veeam_client
+
+    def _cluster(self) -> dict | None:
+        """Get HA cluster data from coordinator data."""
+        return self.coordinator.data.get("ha_cluster") if self.coordinator.data else None
+
+    @property
+    def available(self) -> bool:
+        """A cluster mid-failover cannot take another switchover or failover."""
+        cluster = self._cluster()
+        if cluster is None:
+            return False
+        in_progress = cluster.get("is_failover_in_progress") or cluster.get(
+            "is_endpoint_migration_in_progress"
+        )
+        return super().available and not in_progress
+
+    @property
+    def device_info(self):
+        """Return device info for the HA cluster."""
+        cluster = self._cluster()
+        name = (cluster.get("name") if cluster else None) or "HA Cluster"
+        host = self._config_entry.data.get(CONF_HOST, "Unknown")
+        return {
+            "identifiers": {(DOMAIN, f"ha_cluster_{self._config_entry.entry_id}")},
+            "name": f"{name} ({host})",
+            "manufacturer": "Veeam",
+            "model": "High Availability Cluster",
+        }
+
+    def _api_module(self) -> str:
+        """Resolve the SDK package for the configured API version."""
+        api_version = self._config_entry.options.get(
+            CONF_API_VERSION,
+            self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
+        )
+        return API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
+
+
+class VeeamHAClusterSwitchoverButton(VeeamHAClusterButtonBase):
+    """Button to switch the cluster over to its secondary node."""
+
+    def __init__(self, coordinator, config_entry, veeam_client):
+        """Initialize the button."""
+        super().__init__(coordinator, config_entry, veeam_client)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_switchover"
+        self._attr_name = "Switchover"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the button."""
+        return "mdi:swap-horizontal"
+
+    async def async_press(self) -> None:
+        """Handle the button press to switch the cluster over."""
+        try:
+            api_module = self._api_module()
+
+            # The spec is optional; sending it explicitly keeps the lag check in force, so a
+            # switchover with a badly lagging secondary is refused by the server instead of
+            # silently promoting a stale node.
+            body = None
+            try:
+                models_module = await asyncio.to_thread(
+                    importlib.import_module,
+                    f"veeam_br.{api_module}.models.high_availability_switchover_spec",
+                )
+                body = models_module.HighAvailabilitySwitchoverSpec(ignore_lag=False)
+            except (ImportError, AttributeError) as err:
+                _LOGGER.debug(
+                    "HighAvailabilitySwitchoverSpec unavailable (%s); "
+                    "requesting switchover without a body",
+                    err,
+                )
+
+            try:
+                ha_api = await asyncio.to_thread(
+                    self._veeam_client.api, "high_availability_ha_cluster"
+                )
+                kwargs = {"body": body} if body is not None else {}
+                await self._veeam_client.call(ha_api.switchover_high_availability_cluster, **kwargs)
+                _LOGGER.info("Requested HA cluster switchover")
+                await self.coordinator.async_request_refresh()
+            except Exception as call_err:
+                _LOGGER.error("Failed to switch over the HA cluster: %s", call_err)
+                raise
+
+        except Exception as err:
+            _LOGGER.error("Error switching over the HA cluster: %s", err)
+            raise
+
+
+class VeeamHAClusterFailoverButton(VeeamHAClusterButtonBase):
+    """Button to fail the cluster over to its secondary node."""
+
+    # Unplanned failover promotes the secondary without waiting for the primary. It is an
+    # emergency action, so it ships disabled and the user enables it consciously.
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator, config_entry, veeam_client):
+        """Initialize the button."""
+        super().__init__(coordinator, config_entry, veeam_client)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_failover"
+        self._attr_name = "Failover"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the button."""
+        return "mdi:alert-octagon"
+
+    async def async_press(self) -> None:
+        """Handle the button press to fail the cluster over."""
+        try:
+            ha_api = await asyncio.to_thread(self._veeam_client.api, "high_availability_ha_cluster")
+            await self._veeam_client.call(ha_api.failover_high_availability_cluster)
+            _LOGGER.warning("Requested HA cluster failover")
+            await self.coordinator.async_request_refresh()
+        except Exception as err:
+            _LOGGER.error("Failed to fail over the HA cluster: %s", err)
             raise

--- a/custom_components/veeam_br/const.py
+++ b/custom_components/veeam_br/const.py
@@ -138,4 +138,8 @@ API_FEATURE_REQUIREMENTS = {
     "sobr_data": "api.repositories",  # SOBRs use repositories API
     "license_data": "api.license_",
     "server_data": "api.service",
+    # High Availability cluster: API 1.3-rev2 (VBR 13.1) and newer only
+    "ha_cluster_data": "api.high_availability_ha_cluster",
+    "ha_cluster_switchover_button": "models.high_availability_switchover_spec",
+    "ha_cluster_failover_button": "api.high_availability_ha_cluster",
 }

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -34,11 +34,13 @@ async def async_setup_entry(
     added_sobr_ids: set[str] = set()
     server_added = False
     license_added = False
+    ha_cluster_added = False
 
     @callback
     def _sync_entities() -> None:
         nonlocal server_added
         nonlocal license_added
+        nonlocal ha_cluster_added
 
         if not coordinator.data:
             return
@@ -174,6 +176,32 @@ async def async_setup_entry(
                 ]
             )
             license_added = True
+
+        # ---- HA CLUSTER SENSORS (once) - clustered servers on 1.3-rev2 and newer only ----
+        if (
+            not ha_cluster_added
+            and coordinator.data.get("ha_cluster")
+            and check_api_feature_availability(api_version, "api.high_availability_ha_cluster")
+        ):
+            new_entities.extend(
+                [
+                    VeeamHAClusterOnlineSensor(coordinator, entry),
+                    VeeamHAClusterFailoverInProgressSensor(coordinator, entry),
+                    VeeamHAClusterMaintenanceSensor(coordinator, entry),
+                    VeeamHAClusterLastOnlineSensor(coordinator, entry),
+                    VeeamHAClusterEndpointSensor(coordinator, entry),
+                ]
+            )
+            for node_key, node_label in (("primary", "Primary"), ("secondary", "Secondary")):
+                new_entities.extend(
+                    [
+                        VeeamHAClusterNodeStateSensor(coordinator, entry, node_key, node_label),
+                        VeeamHAClusterNodeRoleSensor(coordinator, entry, node_key, node_label),
+                        VeeamHAClusterNodeLagSensor(coordinator, entry, node_key, node_label),
+                    ]
+                )
+            ha_cluster_added = True
+            _LOGGER.debug("Adding HA cluster sensors")
 
         if new_entities:
             _LOGGER.debug("Adding %d Veeam sensors", len(new_entities))
@@ -1403,3 +1431,269 @@ class VeeamSOBRExtentCountSensor(VeeamSOBRBaseSensor):
     @property
     def icon(self) -> str:
         return "mdi:counter"
+
+
+# ===========================
+# HIGH AVAILABILITY CLUSTER (device per config entry)
+#
+# Only present on API 1.3-rev2 (VBR 13.1) and newer, and only when the server is actually
+# clustered. Node roles come from Patroni: Leader, Replica, StandbyLeader, SyncStandby.
+# ===========================
+
+
+class VeeamHAClusterMixin:
+    """Mixin providing shared HA cluster functionality."""
+
+    def __init__(self, coordinator, config_entry):
+        """Initialize the mixin."""
+        self._config_entry = config_entry
+
+    def _cluster(self) -> dict[str, Any] | None:
+        """Get HA cluster data from coordinator data."""
+        return self.coordinator.data.get("ha_cluster") if self.coordinator.data else None
+
+    def _node(self, which: str) -> dict[str, Any] | None:
+        """Get one cluster node ("primary" or "secondary")."""
+        cluster = self._cluster()
+        return cluster.get(which) if cluster else None
+
+    @property
+    def available(self) -> bool:
+        """A cluster that stops being reported should not keep showing stale values."""
+        return super().available and self._cluster() is not None
+
+    @property
+    def device_info(self):
+        """Return device info for the HA cluster."""
+        cluster = self._cluster()
+        name = (cluster.get("name") if cluster else None) or "HA Cluster"
+        host = self._config_entry.data.get(CONF_HOST, "Unknown")
+        return {
+            "identifiers": {(DOMAIN, f"ha_cluster_{self._config_entry.entry_id}")},
+            "name": f"{name} ({host})",
+            "manufacturer": "Veeam",
+            "model": "High Availability Cluster",
+        }
+
+
+class VeeamHAClusterBaseSensor(VeeamHAClusterMixin, CoordinatorEntity, SensorEntity):
+    """Base class for HA cluster sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamHAClusterMixin.__init__(self, coordinator, config_entry)
+
+
+class VeeamHAClusterBinarySensorBase(VeeamHAClusterMixin, CoordinatorEntity, BinarySensorEntity):
+    """Base class for HA cluster binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamHAClusterMixin.__init__(self, coordinator, config_entry)
+
+
+class VeeamHAClusterOnlineSensor(VeeamHAClusterBinarySensorBase):
+    """Binary sensor for whether the HA cluster is online."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_online"
+        self._attr_name = "Online"
+
+    @property
+    def is_on(self) -> bool | None:
+        cluster = self._cluster()
+        return cluster.get("is_online") if cluster else None
+
+
+class VeeamHAClusterFailoverInProgressSensor(VeeamHAClusterBinarySensorBase):
+    """Binary sensor for an in-progress failover."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_failover_in_progress"
+        self._attr_name = "Failover In Progress"
+
+    @property
+    def is_on(self) -> bool | None:
+        cluster = self._cluster()
+        return cluster.get("is_failover_in_progress") if cluster else None
+
+    @property
+    def icon(self) -> str:
+        return "mdi:swap-horizontal-bold" if self.is_on else "mdi:swap-horizontal"
+
+
+class VeeamHAClusterMaintenanceSensor(VeeamHAClusterBinarySensorBase):
+    """Binary sensor for cluster maintenance mode."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_maintenance"
+        self._attr_name = "Maintenance In Progress"
+
+    @property
+    def is_on(self) -> bool | None:
+        cluster = self._cluster()
+        return cluster.get("is_maintenance_in_progress") if cluster else None
+
+    @property
+    def icon(self) -> str:
+        return "mdi:wrench-clock" if self.is_on else "mdi:wrench"
+
+
+class VeeamHAClusterLastOnlineSensor(VeeamHAClusterBaseSensor):
+    """Sensor for when the cluster was last online."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_last_online"
+        self._attr_name = "Last Online"
+
+    @property
+    def native_value(self):
+        cluster = self._cluster()
+        return cluster.get("last_online_time") if cluster else None
+
+    @property
+    def icon(self) -> str:
+        return "mdi:clock-check"
+
+
+class VeeamHAClusterEndpointSensor(VeeamHAClusterBaseSensor):
+    """Sensor for the cluster endpoint."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_endpoint"
+        self._attr_name = "Cluster Endpoint"
+
+    @property
+    def native_value(self) -> str | None:
+        cluster = self._cluster()
+        return cluster.get("cluster_endpoint") if cluster else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        cluster = self._cluster() or {}
+        return {
+            "dns_name": cluster.get("cluster_dns_name"),
+            "cross_subnet_mode": cluster.get("is_cross_subnet_mode"),
+            "endpoint_migration_in_progress": cluster.get("is_endpoint_migration_in_progress"),
+        }
+
+    @property
+    def icon(self) -> str:
+        return "mdi:ip-network"
+
+
+class VeeamHAClusterNodeSensorBase(VeeamHAClusterBaseSensor):
+    """Base class for a sensor reporting on one cluster node."""
+
+    def __init__(self, coordinator, config_entry, node_key, node_label):
+        super().__init__(coordinator, config_entry)
+        self._node_key = node_key
+        self._node_label = node_label
+
+    def _node_data(self) -> dict[str, Any] | None:
+        return self._node(self._node_key)
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._node_data() is not None
+
+
+class VeeamHAClusterNodeStateSensor(VeeamHAClusterNodeSensorBase):
+    """Sensor for a node's replication state."""
+
+    def __init__(self, coordinator, config_entry, node_key, node_label):
+        super().__init__(coordinator, config_entry, node_key, node_label)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_{node_key}_state"
+        self._attr_name = f"{node_label} Node State"
+
+    @property
+    def native_value(self) -> str | None:
+        node = self._node_data()
+        return node.get("state") if node else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        node = self._node_data() or {}
+        return {
+            "name": node.get("name"),
+            "role": node.get("role"),
+            "ip_address": node.get("ip_address"),
+            "fqdn": node.get("fqdn"),
+            "timeline": node.get("timeline"),
+            "external_endpoint": node.get("external_endpoint"),
+        }
+
+    @property
+    def icon(self) -> str:
+        state = (self.native_value or "").lower()
+        if state in ("running", "streaming"):
+            return "mdi:database-check"
+        if state in ("crashed", "initdbfailed", "restartfailed", "startfailed", "stopfailed"):
+            return "mdi:database-alert"
+        if state == "stopped":
+            return "mdi:database-off"
+        return "mdi:database-clock"
+
+
+class VeeamHAClusterNodeRoleSensor(VeeamHAClusterNodeSensorBase):
+    """Sensor for a node's cluster role."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, node_key, node_label):
+        super().__init__(coordinator, config_entry, node_key, node_label)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_{node_key}_role"
+        self._attr_name = f"{node_label} Node Role"
+
+    @property
+    def native_value(self) -> str | None:
+        node = self._node_data()
+        return node.get("role") if node else None
+
+    @property
+    def icon(self) -> str:
+        leader = (self.native_value or "").lower() == "leader"
+        return "mdi:crown" if leader else "mdi:account-group"
+
+
+class VeeamHAClusterNodeLagSensor(VeeamHAClusterNodeSensorBase):
+    """Sensor for a node's replication lag."""
+
+    _attr_native_unit_of_measurement = "MB"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, config_entry, node_key, node_label):
+        super().__init__(coordinator, config_entry, node_key, node_label)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_{node_key}_lag"
+        self._attr_name = f"{node_label} Node Lag"
+
+    @property
+    def native_value(self) -> int | float | None:
+        node = self._node_data()
+        lag = node.get("lag_mb") if node else None
+        return lag if isinstance(lag, (int, float)) else None
+
+    @property
+    def icon(self) -> str:
+        return "mdi:timer-sand"

--- a/tests/test_ha_cluster.py
+++ b/tests/test_ha_cluster.py
@@ -1,0 +1,312 @@
+"""Tests for High Availability cluster support (VBR 13.1, API 1.3-rev2).
+
+The parse helpers live in __init__.py, which imports Home Assistant, so they are loaded
+from source into a module stubbed with just the names they use. That keeps the assertions
+behavioural — real payloads in, coordinator data out — without needing Home Assistant
+installed, which this repo's test environment does not have.
+"""
+
+import ast
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+
+import pytest
+
+INIT_PATH = Path(__file__).parent.parent / "custom_components" / "veeam_br" / "__init__.py"
+BUTTON_PATH = Path(__file__).parent.parent / "custom_components" / "veeam_br" / "button.py"
+SENSOR_PATH = Path(__file__).parent.parent / "custom_components" / "veeam_br" / "sensor.py"
+
+HELPERS = (
+    "_bool_or_none",
+    "_parse_ha_cluster_node",
+    "_parse_ha_cluster_last_online",
+    "_parse_ha_cluster",
+)
+
+
+def _parse_datetime(value):
+    """Stand-in for homeassistant.util.dt.parse_datetime."""
+    value = re.sub(r"\.(\d{6})\d+", r".\1", value)
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+@pytest.fixture(name="helpers", scope="module")
+def helpers_fixture():
+    """Execute just the HA cluster helpers from __init__.py."""
+    tree = ast.parse(INIT_PATH.read_text(encoding="utf-8"))
+    wanted = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in HELPERS
+    ]
+    assert len(wanted) == len(HELPERS), f"expected {HELPERS} in __init__.py, found {wanted}"
+
+    namespace = {
+        "dt_util": type("dt_util", (), {"parse_datetime": staticmethod(_parse_datetime)}),
+        "timezone": timezone,
+    }
+    exec(compile(ast.Module(body=wanted, type_ignores=[]), str(INIT_PATH), "exec"), namespace)
+    return namespace
+
+
+# Helpers the coordinator passes in, matching the real ones in async_update_data
+def get_enum_value(value, default="unknown"):
+    if value is None:
+        return default
+    return getattr(value, "value", None) or str(value)
+
+
+def get_uuid_value(value):
+    return str(value) if value is not None else None
+
+
+def serialize_value(value):
+    return value
+
+
+class Enum:
+    """Stands in for a generated str-enum."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+class Node:
+    def __init__(self, **kwargs):
+        self.id = "6f1f0f8a-0000-4000-8000-000000000001"
+        self.name = "vbr-node-1"
+        self.ip_address = "10.0.0.11"
+        self.fqdn = "vbr-node-1.example.com"
+        self.role = Enum("Leader")
+        self.state = Enum("Running")
+        self.timeline = "3"
+        self.lag_mb = 0
+        self.external_endpoint = None
+        self.__dict__.update(kwargs)
+
+
+class States:
+    def __init__(self, **kwargs):
+        self.is_creation_in_progress = False
+        self.is_failover_in_progress = False
+        self.is_removal_in_progress = False
+        self.is_first_launch_after_failover = False
+        self.is_cluster_endpoint_migration_in_progress = False
+        self.last_online_time_utc = "2026-08-12T09:30:00.0000000Z"
+        self.is_online = True
+        self.is_secondary_reinit_in_progress = False
+        self.is_maintenance_in_progress = False
+        self.__dict__.update(kwargs)
+
+
+class Cluster:
+    def __init__(self, **kwargs):
+        self.id = "aaaaaaaa-0000-4000-8000-000000000009"
+        self.name = "VBR-HA"
+        self.cluster_endpoint = "10.0.0.10"
+        self.cluster_dns_name = "vbr-ha.example.com"
+        self.is_cross_subnet_mode = False
+        self.states = States()
+        self.primary_node = Node()
+        self.secondary_node = Node(
+            name="vbr-node-2",
+            ip_address="10.0.0.12",
+            role=Enum("SyncStandby"),
+            state=Enum("Streaming"),
+            lag_mb=12,
+        )
+        self.additional_properties = {}
+        self.__dict__.update(kwargs)
+
+
+def parse(helpers, cluster):
+    return helpers["_parse_ha_cluster"](cluster, get_enum_value, get_uuid_value, serialize_value)
+
+
+def test_parses_a_healthy_cluster(helpers):
+    """A clustered server should yield the fields the sensors read."""
+    parsed = parse(helpers, Cluster())
+
+    assert parsed["name"] == "VBR-HA"
+    assert parsed["cluster_endpoint"] == "10.0.0.10"
+    assert parsed["cluster_dns_name"] == "vbr-ha.example.com"
+    assert parsed["is_online"] is True
+    assert parsed["is_failover_in_progress"] is False
+    assert parsed["primary"]["role"] == "Leader"
+    assert parsed["secondary"]["role"] == "SyncStandby"
+    assert parsed["secondary"]["lag_mb"] == 12
+
+
+def test_last_online_time_is_timezone_aware(helpers):
+    """Timestamp sensors reject naive datetimes, and the field is documented as UTC."""
+    parsed = parse(helpers, Cluster())
+
+    assert parsed["last_online_time"] == datetime(2026, 8, 12, 9, 30, tzinfo=timezone.utc)
+    assert parsed["last_online_time"].tzinfo is not None
+
+
+def test_last_online_time_without_offset_is_stamped_utc(helpers):
+    """Veeam types the field as a plain string, so an offset is not guaranteed."""
+    parsed = parse(helpers, Cluster(states=States(last_online_time_utc="2026-08-12T09:30:00")))
+
+    assert parsed["last_online_time"] == datetime(2026, 8, 12, 9, 30, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    [None, "", "not a timestamp", 12345, object()],
+    ids=["none", "empty", "unparseable", "number", "object"],
+)
+def test_unusable_last_online_time_is_none(helpers, raw_value):
+    """A bad timestamp should not lose the whole cluster."""
+    parsed = parse(helpers, Cluster(states=States(last_online_time_utc=raw_value)))
+
+    assert parsed["last_online_time"] is None
+    assert parsed["name"] == "VBR-HA", "the rest of the cluster should still parse"
+
+
+def test_missing_states_leaves_flags_unknown(helpers):
+    """states is optional in the schema; absent flags must not read as False."""
+    parsed = parse(helpers, Cluster(states=None))
+
+    for flag in ("is_online", "is_failover_in_progress", "is_maintenance_in_progress"):
+        assert parsed[flag] is None, f"{flag} should be unknown, not False"
+    assert parsed["last_online_time"] is None
+    assert parsed["cluster_endpoint"] == "10.0.0.10", "configuration should still parse"
+
+
+def test_unset_flags_read_as_none(helpers):
+    """UNSET is not a bool, and must not be reported as one."""
+
+    class Unset:
+        pass
+
+    parsed = parse(helpers, Cluster(states=States(is_online=Unset())))
+
+    assert parsed["is_online"] is None
+
+
+def test_missing_secondary_node_is_none(helpers):
+    """A half-built cluster should still report its primary."""
+    parsed = parse(helpers, Cluster(secondary_node=None))
+
+    assert parsed["primary"]["name"] == "vbr-node-1"
+    assert parsed["secondary"] is None
+
+
+def test_non_string_external_endpoint_is_dropped(helpers):
+    """externalEndpoint is a nullable union in the schema."""
+
+    class Unset:
+        pass
+
+    parsed = parse(helpers, Cluster(primary_node=Node(external_endpoint=Unset())))
+
+    assert parsed["primary"]["external_endpoint"] is None
+
+
+def test_non_numeric_lag_is_dropped(helpers):
+    """Lag feeds a measurement sensor, which must not receive a sentinel."""
+
+    class Unset:
+        pass
+
+    parsed = parse(helpers, Cluster(primary_node=Node(lag_mb=Unset())))
+
+    assert parsed["primary"]["lag_mb"] is None
+
+
+def test_additional_properties_are_carried_through(helpers):
+    """Fields Veeam adds later should still reach diagnostics."""
+    parsed = parse(helpers, Cluster(additional_properties={"newFlag": True}))
+
+    assert parsed["newFlag"] is True
+
+
+def test_additional_properties_cannot_overwrite_parsed_fields(helpers):
+    """A stray key must not clobber a field the sensors depend on."""
+    parsed = parse(helpers, Cluster(additional_properties={"name": "not-the-name"}))
+
+    assert parsed["name"] == "VBR-HA"
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the endpoints are 1.3-rev2 only, and failover is a dangerous action
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_fetch_is_version_guarded():
+    """Older API versions do not have the endpoint; the call must be skipped, not failed."""
+    content = INIT_PATH.read_text(encoding="utf-8")
+
+    assert 'HA_CLUSTER_FEATURE = "api.high_availability_ha_cluster"' in content
+    assert (
+        "check_api_feature_availability(api_version, HA_CLUSTER_FEATURE)" in content
+    ), "HA cluster support should be probed through the shared feature check"
+
+    fetch = content.index("get_high_availability_cluster")
+    guard = content.rindex("if ha_cluster_supported:", 0, fetch)
+    assert guard < fetch, "the fetch should sit behind the support flag"
+
+
+def test_unclustered_server_is_not_an_error():
+    """Most servers are not clustered; that must not log a warning every poll."""
+    content = INIT_PATH.read_text(encoding="utf-8")
+
+    marker = "No HA cluster reported by this server"
+    assert marker in content
+    line_start = content.rindex("_LOGGER.", 0, content.index(marker))
+    assert content[line_start:].startswith(
+        "_LOGGER.debug"
+    ), "an unclustered server should be a debug message, not a warning"
+
+
+def test_failover_button_is_disabled_by_default():
+    """Failover is an emergency action and buttons have no confirmation step."""
+    content = BUTTON_PATH.read_text(encoding="utf-8")
+
+    failover = content.index("class VeeamHAClusterFailoverButton")
+    switchover = content.index("class VeeamHAClusterSwitchoverButton")
+    failover_block = content[failover:]
+
+    assert (
+        "_attr_entity_registry_enabled_default = False" in failover_block
+    ), "the failover button should ship disabled"
+
+    switchover_block = content[switchover:failover]
+    assert (
+        "_attr_entity_registry_enabled_default" not in switchover_block
+    ), "switchover is the planned operation and should be enabled"
+
+
+def test_switchover_keeps_the_lag_check():
+    """Promoting a badly lagging secondary should stay the server's call to refuse."""
+    content = BUTTON_PATH.read_text(encoding="utf-8")
+
+    assert (
+        "HighAvailabilitySwitchoverSpec(ignore_lag=False)" in content
+    ), "switchover should not ask the server to ignore replication lag"
+
+
+def test_cluster_buttons_unavailable_during_failover():
+    """A second press must not pile onto a running operation."""
+    content = BUTTON_PATH.read_text(encoding="utf-8")
+
+    base = content[content.index("class VeeamHAClusterButtonBase") :]
+    base = base[: base.index("class VeeamHAClusterSwitchoverButton")]
+
+    assert "is_failover_in_progress" in base
+    assert "def available" in base
+
+
+def test_cluster_entities_require_reported_cluster():
+    """Entities should go unavailable rather than show stale values."""
+    content = SENSOR_PATH.read_text(encoding="utf-8")
+
+    mixin = content[content.index("class VeeamHAClusterMixin") :]
+    mixin = mixin[: mixin.index("class VeeamHAClusterBaseSensor")]
+
+    assert "def available" in mixin
+    assert "self._cluster() is not None" in mixin


### PR DESCRIPTION
Veeam B&R 13.1 exposes its High Availability cluster over the REST API (`1.3-rev2`):
cluster state, failover, and switchover. This adds monitoring and both actions.

## Scope

The endpoints are `1.3-rev2` only, so the fetch sits behind `check_api_feature_availability`
and older API versions never make the call. A server that is not clustered answers with an
`Error` model — the common case — so it logs at debug and creates no device, rather than
warning every 60 seconds.

## Entities

One **High Availability Cluster** device per clustered server:

| Entity | Notes |
| ------ | ----- |
| Online | Connectivity of the cluster as a whole |
| Failover In Progress | The one an automation is most likely to gate on |
| Maintenance In Progress | Diagnostic |
| Last Online | Diagnostic timestamp |
| Cluster Endpoint | Diagnostic; DNS name, cross-subnet mode, endpoint migration as attributes |
| Primary / Secondary Node State | Patroni state — `Running`, `Streaming`, `Crashed`, … |
| Primary / Secondary Node Role | `Leader`, `Replica`, `StandbyLeader`, `SyncStandby` |
| Primary / Secondary Node Lag | Replication lag in MB, as a measurement |

Entities go unavailable rather than showing stale values if the server stops reporting a
cluster, and the per-node sensors do the same for a node that drops out of the response.

## Buttons, and the safety call

- **Switchover** — the planned, graceful role swap. Enabled by default; this is the operation
  the release notes point at for HA workflow automation.
- **Failover** — promotes the secondary without waiting for the primary. **Disabled by
  default** (`entity_registry_enabled_default = False`).

HA buttons fire with no confirmation step. Automating an emergency promotion is reasonable;
triggering it by mis-tapping a dashboard is not, so enabling that entity is a deliberate act.

Switchover sends `HighAvailabilitySwitchoverSpec(ignore_lag=False)` explicitly, so Veeam
keeps enforcing its replication-lag check and refuses to promote a badly lagging secondary,
instead of depending on whatever the server default happens to be. Both buttons report
unavailable while a failover or endpoint migration is already running, so a second press
cannot pile onto a running operation.

## Not included

`create`, `change` and `delete` cluster also exist in rev2. Building or destroying a database
cluster from a Home Assistant dashboard is not something this PR takes on: they need complex
specs (`HighAvailabilityClusterSpec`, certificates, address specs) and there is no safe UI
affordance for them. Easy to add later if wanted.

## Notes on the data

`lastOnlineTimeUtc` is typed as a plain string in Veeam's schema, so it is parsed in the
coordinator and stamped UTC when it carries no offset — timestamp sensors require an aware
datetime. `states` is optional, so its flags read as *unknown* rather than `False` when
absent.

## Tests

21 new tests, 70 total. The parse helpers live in `__init__.py`, which imports Home
Assistant, and this repo's test environment has none — so rather than settle for source-text
assertions, the tests lift those functions out with `ast` and run them against stand-in
payloads. They cover what Veeam's schema permits: absent `states`, `UNSET` flags, a timestamp
with no offset, unparseable and non-string timestamps, a missing secondary node, non-numeric
lag reaching a measurement sensor, and additional properties that must reach diagnostics
without clobbering parsed fields.

They also pin the decisions above: the version guard, debug-not-warning for unclustered
servers, failover disabled while switchover stays enabled, `ignore_lag=False`, and buttons
unavailable mid-failover.
