### PR TITLE
Auto-detect the API version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is an independent, open source project. It is not affiliated with, 
 ## Features
 
 - 🔧 **UI Configuration Flow**: Easy setup through Home Assistant's UI
+- 🔎 **API Version Auto-Detection**: Finds the newest REST API revision your server serves
 - 📊 **Job Monitoring**: Track all backup jobs and their current status
 - 🔄 **Automatic Updates**: Polls the Veeam server every 60 seconds
 - 🎨 **Dynamic Icons**: Visual indicators based on job status (success, running, failed, warning)
@@ -31,9 +32,20 @@ This project is an independent, open source project. It is not affiliated with, 
 ### Supported API Versions
 
 The **API Version** option selects the REST API revision used against your server. It
-defaults to the newest revision; on an older server, pick the revision matching your VBR
-release. Veeam also serves older revisions to newer servers, so a lower revision is a safe
-choice if you are unsure.
+defaults to **auto**, which probes the server and picks the newest revision it serves, so you
+do not need to know your VBR build. Pick a specific revision to pin it instead.
+
+Detection works by asking the server which Swagger documents it publishes — Veeam's REST API
+has no endpoint that reports its own supported versions, and
+[Veeam's guidance](https://community.veeam.com/discussion-boards-66/for-veeam-backup-and-replication-rest-apis-x-api-version-header-for-example-1-3-rev1-can-be-obtained-from-a-rest-api-13741)
+is that the caller chooses one. If the Swagger endpoints are unreachable or disabled,
+detection is skipped and the newest supported revision is used; select a revision manually if
+that is wrong for your server.
+
+The detected revision is **resolved once** and stored, when the entry is created or its
+options are changed. Upgrading VBR does not silently move an existing entry onto a newer
+revision — re-run **Configure** and choose *auto* again to pick up a newer one. Veeam also
+serves older revisions to newer servers, so a pinned lower revision stays a safe choice.
 
 | VBR Version | API Version | Notes |
 | ----------- | ----------- | ----- |
@@ -82,7 +94,8 @@ The integration supports the following configuration options:
 #### Optional Parameters
 - **Verify SSL**: Enable/disable SSL certificate verification (default: enabled)
   - Disable only if using self-signed certificates in a trusted environment
-- **API Version**: Select the Veeam REST API version to use (configured via integration options)
+- **API Version**: REST API revision to use. Defaults to *auto*, which detects the newest
+  revision the server serves (configured via integration options)
 
 ### Via UI (Recommended)
 

--- a/custom_components/veeam_br/config_flow.py
+++ b/custom_components/veeam_br/config_flow.py
@@ -16,6 +16,7 @@ import voluptuous as vol
 
 from .const import (
     API_VERSIONS,
+    AUTO_API_VERSION,
     CONF_API_VERSION,
     CONF_VERIFY_SSL,
     DEFAULT_API_MODULE,
@@ -32,20 +33,57 @@ _LOGGER = logging.getLogger(__name__)
 def _get_api_version_selector_config(
     preferred_version: str | None = None,
 ) -> tuple[list[str], str]:
-    """Get API version options and default for selector."""
-    api_version_options = list(API_VERSIONS.keys())
+    """Get API version options and default for selector.
+
+    AUTO_API_VERSION leads the list and is the default, so the common case is not asking
+    the user to know which revision their server speaks.
+    """
+    api_version_options = [AUTO_API_VERSION, *API_VERSIONS.keys()]
 
     if preferred_version and preferred_version in api_version_options:
         return api_version_options, preferred_version
 
-    if DEFAULT_API_VERSION in api_version_options:
-        return api_version_options, DEFAULT_API_VERSION
+    return api_version_options, AUTO_API_VERSION
 
-    if api_version_options:
-        return api_version_options, api_version_options[0]
 
-    _LOGGER.error("No API versions available, using fallback")
-    return [DEFAULT_API_VERSION], DEFAULT_API_VERSION
+async def async_resolve_api_version(data: dict[str, Any]) -> str:
+    """Resolve the configured API version, detecting it when set to auto.
+
+    Detection probes the server's Swagger documents (see veeam_br.discovery) and needs no
+    credentials, so it runs before the connection is validated. It is best-effort: a server
+    with Swagger disabled or gated reports nothing, and the static default is used instead
+    of failing setup.
+    """
+    api_version = data.get(CONF_API_VERSION, AUTO_API_VERSION)
+    if api_version != AUTO_API_VERSION:
+        return api_version
+
+    from veeam_br.discovery import detect_api_version
+
+    base_url = f"https://{data[CONF_HOST]}:{data[CONF_PORT]}"
+    verify_ssl = data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+
+    try:
+        detected = await detect_api_version(
+            base_url,
+            verify_ssl=verify_ssl,
+            versions=list(API_VERSIONS),
+        )
+    except Exception as err:  # noqa: BLE001 - detection must never fail the flow
+        _LOGGER.debug("API version detection failed: %s", err)
+        detected = None
+
+    if detected is None:
+        _LOGGER.info(
+            "Could not detect the API version of %s; using %s. Select a version manually "
+            "if this server needs a different one",
+            data[CONF_HOST],
+            DEFAULT_API_VERSION,
+        )
+        return DEFAULT_API_VERSION
+
+    _LOGGER.info("Detected API version %s on %s", detected, data[CONF_HOST])
+    return detected
 
 
 def _load_veeam_br(api_version: str):
@@ -78,8 +116,14 @@ def _load_veeam_br(api_version: str):
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect."""
-    api_version = data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
+    """Validate the user input allows us to connect.
+
+    Mutates data[CONF_API_VERSION] when it is set to auto, so the caller stores the resolved
+    version rather than the sentinel: a server upgrade must not silently move an existing
+    entry onto a newer revision, where enum values are renamed and fields added.
+    """
+    api_version = await async_resolve_api_version(data)
+    data[CONF_API_VERSION] = api_version
 
     try:
         VeeamClient = await hass.async_add_executor_job(_load_veeam_br, api_version)
@@ -296,9 +340,15 @@ class VeeamBROptionsFlow(config_entries.OptionsFlow):
                 _LOGGER.exception("Unexpected exception validating options")
                 errors["base"] = "unknown"
             else:
-                return self.async_create_entry(title="", data=user_input)
+                # validate_input resolved auto into a concrete version; store that rather
+                # than the sentinel, so the entry keeps talking the same revision after a
+                # server upgrade
+                return self.async_create_entry(
+                    title="",
+                    data={**user_input, CONF_API_VERSION: test_data[CONF_API_VERSION]},
+                )
 
-        api_version_options = list(API_VERSIONS.keys())
+        api_version_options = [AUTO_API_VERSION, *API_VERSIONS.keys()]
 
         current_api_version = self.config_entry.options.get(
             CONF_API_VERSION,

--- a/custom_components/veeam_br/const.py
+++ b/custom_components/veeam_br/const.py
@@ -21,6 +21,12 @@ DEFAULT_VERIFY_SSL = True
 # revision the server does not serve fails at setup rather than silently.
 DEFAULT_API_VERSION = "1.3-rev2"
 
+# Selector sentinel: probe the server for the newest API version it serves (see
+# api_discovery). Never stored on a config entry — it resolves to a concrete version when
+# the entry is created or reconfigured, so a later server upgrade cannot silently change
+# which revision an existing entry talks.
+AUTO_API_VERSION = "auto"
+
 _LOGGER = logging.getLogger(__name__)
 
 # Fallback used when the veeam-br package cannot be inspected. Mirrors the

--- a/custom_components/veeam_br/manifest.json
+++ b/custom_components/veeam_br/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Cenvora/ha-veeam-br/issues",
   "requirements": [
-    "veeam-br>=0.3.1,<1.0.0"
+    "veeam-br>=0.4.0,<1.0.0"
   ],
   "version": "0.5.0b1"
 }

--- a/custom_components/veeam_br/strings.json
+++ b/custom_components/veeam_br/strings.json
@@ -18,7 +18,7 @@
           "username": "Username with administrator privileges",
           "password": "Password for the specified user account",
           "verify_ssl": "Enable SSL certificate verification (disable only for self-signed certificates)",
-          "api_version": "Veeam REST API version to use"
+          "api_version": "Leave on 'auto' to detect the newest API version this server serves, or pick a version to pin it."
         }
       },
       "reconfigure": {
@@ -75,7 +75,7 @@
           "api_version": "API Version"
         },
         "data_description": {
-          "api_version": "Select the Veeam REST API version to use for this integration"
+          "api_version": "Select 'auto' to re-detect the newest API version this server serves."
         }
       }
     },

--- a/custom_components/veeam_br/translations/en.json
+++ b/custom_components/veeam_br/translations/en.json
@@ -18,7 +18,7 @@
           "username": "Username with administrator privileges",
           "password": "Password for the specified user account",
           "verify_ssl": "Enable SSL certificate verification (disable only for self-signed certificates)",
-          "api_version": "Veeam REST API version to use"
+          "api_version": "Leave on 'auto' to detect the newest API version this server serves, or pick a version to pin it."
         }
       },
       "reconfigure": {
@@ -75,7 +75,7 @@
           "api_version": "API Version"
         },
         "data_description": {
-          "api_version": "Select the Veeam REST API version to use for this integration"
+          "api_version": "Select 'auto' to re-detect the newest API version this server serves."
         }
       }
     },

--- a/tests/test_api_version_resolution.py
+++ b/tests/test_api_version_resolution.py
@@ -1,0 +1,197 @@
+"""Tests for auto-detecting the API version (config flow policy).
+
+The detection mechanism lives in veeam_br.discovery and is tested there. What matters here
+is the policy: auto is the default, the sentinel is resolved before anything is stored, a
+server that cannot be probed still gets a working default, and an explicit choice is left
+alone.
+
+config_flow.py imports Home Assistant, which this environment does not have, so
+async_resolve_api_version is lifted out of the source with ast and run against a stubbed
+veeam_br.discovery.
+"""
+
+import ast
+import asyncio
+import json
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
+CONFIG_FLOW_PATH = COMPONENT / "config_flow.py"
+CONST_PATH = COMPONENT / "const.py"
+
+AUTO = "auto"
+SUPPORTED = {
+    "1.2-rev1": "v1_2_rev1",
+    "1.3-rev0": "v1_3_rev0",
+    "1.3-rev1": "v1_3_rev1",
+    "1.3-rev2": "v1_3_rev2",
+}
+DEFAULT = "1.3-rev2"
+
+
+def load_resolver(detected=None, raises=None, record=None):
+    """Load async_resolve_api_version with veeam_br.discovery stubbed out."""
+    tree = ast.parse(CONFIG_FLOW_PATH.read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "async_resolve_api_version"
+    )
+
+    async def detect_api_version(base_url, *, verify_ssl=True, versions=None, **kwargs):
+        if record is not None:
+            record.update(base_url=base_url, verify_ssl=verify_ssl, versions=versions)
+        if raises is not None:
+            raise raises
+        return detected
+
+    # The function imports veeam_br.discovery at call time
+    discovery = types.ModuleType("veeam_br.discovery")
+    discovery.detect_api_version = detect_api_version
+    veeam_br = sys.modules.get("veeam_br") or types.ModuleType("veeam_br")
+    sys.modules["veeam_br"] = veeam_br
+    sys.modules["veeam_br.discovery"] = discovery
+
+    namespace = {
+        "AUTO_API_VERSION": AUTO,
+        "API_VERSIONS": SUPPORTED,
+        "CONF_API_VERSION": "api_version",
+        "CONF_HOST": "host",
+        "CONF_PORT": "port",
+        "CONF_VERIFY_SSL": "verify_ssl",
+        "DEFAULT_API_VERSION": DEFAULT,
+        "DEFAULT_VERIFY_SSL": True,
+        "_LOGGER": types.SimpleNamespace(debug=lambda *a, **k: None, info=lambda *a, **k: None),
+        "Any": object,
+    }
+    exec(
+        compile(ast.Module(body=[func], type_ignores=[]), str(CONFIG_FLOW_PATH), "exec"),
+        namespace,
+    )
+    return namespace["async_resolve_api_version"]
+
+
+def entry(**overrides):
+    data = {"host": "vbr.example.com", "port": 9419, "api_version": AUTO}
+    data.update(overrides)
+    return data
+
+
+def resolve(resolver, data):
+    return asyncio.run(resolver(data))
+
+
+def test_auto_resolves_to_the_detected_version():
+    resolver = load_resolver(detected="1.3-rev0")
+
+    assert resolve(resolver, entry()) == "1.3-rev0"
+
+
+def test_detection_is_told_only_supported_versions():
+    """Probing a version the SDK cannot speak would produce an unusable answer."""
+    record = {}
+    resolver = load_resolver(detected="1.3-rev1", record=record)
+
+    resolve(resolver, entry())
+
+    assert record["versions"] == list(SUPPORTED)
+    assert record["base_url"] == "https://vbr.example.com:9419"
+
+
+def test_verify_ssl_is_passed_through():
+    """A self-signed server must be probeable, or detection never works there."""
+    record = {}
+    resolver = load_resolver(detected="1.3-rev1", record=record)
+
+    resolve(resolver, entry(verify_ssl=False))
+
+    assert record["verify_ssl"] is False
+
+
+def test_undetectable_server_falls_back_to_the_default():
+    """Swagger may be disabled or gated; setup should still proceed."""
+    resolver = load_resolver(detected=None)
+
+    assert resolve(resolver, entry()) == DEFAULT
+
+
+def test_detection_failure_falls_back_to_the_default():
+    """A raising probe must not break the config flow."""
+    resolver = load_resolver(raises=OSError("network unreachable"))
+
+    assert resolve(resolver, entry()) == DEFAULT
+
+
+@pytest.mark.parametrize("chosen", sorted(SUPPORTED))
+def test_an_explicit_choice_is_never_overridden(chosen):
+    """A user who pinned a version means it, even if the server serves a newer one."""
+    record = {}
+    resolver = load_resolver(detected="1.3-rev2", record=record)
+
+    assert resolve(resolver, entry(api_version=chosen)) == chosen
+    assert record == {}, "no probing should happen when a version is pinned"
+
+
+def test_missing_api_version_is_treated_as_auto():
+    """Entries created before this option existed should still get detection."""
+    data = entry()
+    del data["api_version"]
+    resolver = load_resolver(detected="1.3-rev1")
+
+    assert resolve(resolver, data) == "1.3-rev1"
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_is_never_stored():
+    """The resolved version must reach the config entry, not the sentinel."""
+    content = CONFIG_FLOW_PATH.read_text(encoding="utf-8")
+
+    assert (
+        "data[CONF_API_VERSION] = api_version" in content
+    ), "validate_input should write the resolved version back for the caller to store"
+
+    # The options flow builds its own dict to save, so it needs the resolved value too
+    options = content[content.index("class VeeamBROptionsFlow") :]
+    assert (
+        "CONF_API_VERSION: test_data[CONF_API_VERSION]" in options
+    ), "the options flow must persist the resolved version, not the submitted sentinel"
+
+
+def test_auto_is_offered_and_is_the_default():
+    content = CONFIG_FLOW_PATH.read_text(encoding="utf-8")
+
+    assert "[AUTO_API_VERSION, *API_VERSIONS.keys()]" in content
+    assert (
+        content.count("[AUTO_API_VERSION, *API_VERSIONS.keys()]") == 2
+    ), "both the config flow and the options flow should offer auto"
+    assert "return api_version_options, AUTO_API_VERSION" in content
+
+
+def test_auto_sentinel_is_not_a_real_api_version():
+    """The sentinel must not collide with a version the SDK could ship."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("veeam_br_const", CONST_PATH)
+    const = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(const)
+
+    assert const.AUTO_API_VERSION == AUTO
+    assert const.AUTO_API_VERSION not in const.FALLBACK_API_VERSIONS
+    assert const.AUTO_API_VERSION not in const.API_VERSIONS
+    assert const.AUTO_API_VERSION != const.DEFAULT_API_VERSION
+
+
+def test_auto_option_is_explained_in_strings():
+    """A bare "auto" in a dropdown needs a sentence saying what it does."""
+    for name in ("strings.json", "translations/en.json"):
+        data = json.loads((COMPONENT / name).read_text(encoding="utf-8"))
+        description = data["config"]["step"]["user"]["data_description"]["api_version"]
+        assert "auto" in description.lower()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -631,10 +631,11 @@ def test_manifest_requires_a_recent_enough_veeam_br():
     requirement = next(r for r in manifest["requirements"] if r.startswith("veeam-br"))
 
     # Floors we depend on, newest first:
+    #   0.4.0 — veeam_br.discovery.detect_api_version, used to auto-detect the version
     #   0.3.1 — VeeamClient recovers from a refused token refresh instead of leaving a
     #           dead session behind (issue #82)
     #   0.3.0 — first release shipping the v1_3_rev2 SDK
-    minimum = (0, 3, 1)
+    minimum = (0, 4, 0)
 
     match = re.search(r">=\s*(\d+)\.(\d+)\.(\d+)", requirement)
     assert match, f"veeam-br requirement should pin a minimum version, got {requirement}"


### PR DESCRIPTION
The API Version option now defaults to "auto", which asks the server which Swagger documents it publishes and picks the newest revision it serves — so a user no longer has to know their VBR build to set the integration up.

The probing lives in veeam-br 0.4.0 (veeam_br.discovery.detect_api_version), which is the right home for it: the candidate list is the SDK's own VERSION_TO_PACKAGE, and Veeam's Swagger path convention is API knowledge rather than integration knowledge. What lives here is the policy:

- auto is offered first and is the default, in both the config and options flows
- it resolves to a concrete version in validate_input, before the entry is stored, so upgrading VBR cannot silently move an existing entry onto a newer revision — where enum values get renamed and required fields appear. Picking auto again in Configure re-detects.
- a server whose Swagger endpoints are unreachable, disabled or gated detects nothing, and setup proceeds on DEFAULT_API_VERSION rather than failing
- an explicitly pinned version is never probed or overridden
- verify_ssl is passed through, so a self-signed server is still detectable

The options flow previously saved its submitted input verbatim, which would have persisted the sentinel; it now stores the resolved version.