### PR TITLE
Warn when the server runs an unsupported license

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,147 @@
+name: Bug report
+description: Something is not working — missing entities, errors in the log, failed setup
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this.
+
+        Most reports come down to a handful of things: which Veeam build you run, which REST
+        API revision the integration is using, and what your license entitles. The fields
+        below ask for exactly those, so please fill them in — it is usually the difference
+        between a same-day fix and a long back-and-forth.
+
+        **The fastest thing you can attach is a diagnostics download**: Settings → Devices &
+        Services → Veeam Backup & Replication → ⋮ → *Download diagnostics*. It contains the
+        API version, the veeam-br version, your license edition and server build, with no
+        credentials.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What you expected, and what happened instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Add the integration against a 13.1 server
+        2. …
+    validations:
+      required: false
+
+  - type: input
+    id: vbr-version
+    attributes:
+      label: Veeam Backup & Replication version
+      description: Full build number, e.g. 13.1.0.411. Help → About in the VBR console.
+      placeholder: "13.1.0.411"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: license-edition
+    attributes:
+      label: Veeam license edition
+      description: |
+        License → shown in the VBR console, or in the integration's License device.
+        Community Edition and unlicensed servers are not supported — the integration raises a
+        repair warning for those — but please still report what you see.
+      options:
+        - Enterprise Plus
+        - Enterprise
+        - Standard
+        - Community (free)
+        - No license installed
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api-version
+    attributes:
+      label: Selected API version
+      description: |
+        Settings → Devices & Services → Veeam Backup & Replication → Configure. If you left it
+        on *auto*, pick the revision shown in diagnostics.
+      options:
+        - "auto (detected)"
+        - "1.3-rev2"
+        - "1.3-rev1"
+        - "1.3-rev0"
+        - "1.2-rev1"
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: integration-version
+    attributes:
+      label: Integration version
+      description: HACS, or the `version` field in `manifest.json`.
+      placeholder: "0.5.0b1"
+    validations:
+      required: true
+
+  - type: input
+    id: veeam-br-version
+    attributes:
+      label: veeam-br library version
+      description: From the diagnostics download, or `pip show veeam-br`.
+      placeholder: "0.4.0"
+    validations:
+      required: false
+
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version
+      placeholder: "2026.8.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-type
+    attributes:
+      label: Home Assistant installation type
+      options:
+        - Home Assistant OS
+        - Home Assistant Supervised
+        - Home Assistant Container
+        - Home Assistant Core (venv)
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Settings → System → Logs, or `home-assistant.log`. Enable debug logging first for far
+        more detail:
+
+        ```yaml
+        logger:
+          logs:
+            custom_components.veeam_br: debug
+        ```
+
+        Please paste the text rather than a screenshot, and redact hostnames if you need to.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Attach or paste the diagnostics download. It contains no credentials.
+      render: json
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Veeam REST API library (veeam-br)
+    url: https://github.com/Cenvora/veeam-br/issues
+    about: Report parsing errors, authentication problems, or missing API versions there.
+  - name: Veeam Backup & Replication REST API reference
+    url: https://helpcenter.veeam.com/docs/backup/vbr_rest/overview.html
+    about: Veeam's own documentation for the API this integration uses.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an entity, action, or Veeam capability to support
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What would you like to do?
+      description: |
+        Describe the outcome you are after rather than the implementation — what would you
+        automate or see on a dashboard?
+    validations:
+      required: true
+
+  - type: input
+    id: veeam-feature
+    attributes:
+      label: Veeam feature or REST endpoint
+      description: |
+        If you know which part of Veeam this maps to, name it — an endpoint from
+        `https://<your-server>:9419/swagger/index.html`, or the feature's name in the console.
+      placeholder: "e.g. malware detection events, /api/v1/malwareDetection/events"
+    validations:
+      required: false
+
+  - type: input
+    id: vbr-version
+    attributes:
+      label: Veeam Backup & Replication version
+      description: Which build has this feature, if it is version-specific.
+      placeholder: "13.1.0.411"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Example automations, screenshots, or links to Veeam documentation.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This project is an independent, open source project. It is not affiliated with, 
 ## Requirements
 
 - Home Assistant 2023.1.0 or newer
-- Veeam Backup & Replication server with REST API enabled (Community Edition not supported)
+- Veeam Backup & Replication server with the REST API enabled, on a supported license
+  (see [Licensing](#licensing))
 
 ### Supported API Versions
 
@@ -330,9 +331,29 @@ All devices and entities associated with this integration will be removed.
 - Polling interval is set to 60 seconds to balance freshness and load
 - Consider adjusting via code if needed for very large deployments
 
+## Licensing
+
+This integration is developed and tested against licensed Veeam Backup & Replication
+installations (Enterprise, Enterprise Plus, Standard, and evaluation or NFR licenses).
+
+**Community Edition, and servers with no license installed, are not supported.** Entitlements
+differ between editions, and some REST API endpoints answer differently or not at all, so
+entities can be missing or unreliable in ways that look like integration bugs.
+
+The integration reads the license edition it is already polling for and, if it finds an
+unsupported one, raises a warning under **Settings → Repairs** and logs it on every reload.
+Nothing is blocked: if the integration works for you on Community Edition, it keeps working.
+The warning exists so that unexplained behaviour has an obvious first suspect, and it clears
+itself once the server reports a supported license.
+
+If you report a problem, please include the license edition — the diagnostics download
+(⋮ → *Download diagnostics*) contains it, along with the API version and library version, and
+no credentials.
+
 ## Known Limitations
 
-- **Veeam Community Edition**: Not supported (lacks REST API)
+- **Veeam Community Edition / unlicensed servers**: Not supported. The integration detects
+  this and raises a repair warning, but keeps running — see [Licensing](#licensing).
 - **API Version Compatibility**: Requires Veeam B&R 12.1 or newer
 - **Stale Devices**: Deleted jobs/repositories remain as devices until manual removal (planned enhancement)
 - **Large Deployments**: Polling 100+ jobs may take several seconds per cycle

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -11,6 +11,7 @@ import sys
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -25,6 +26,7 @@ from .const import (
     UPDATE_INTERVAL,
     check_api_feature_availability,
 )
+from .licensing import describe_license, unsupported_license_reason
 from .sdk_patches import patch_models as patch_null_values_in_models
 
 _LOGGER = logging.getLogger(__name__)
@@ -122,6 +124,49 @@ def _parse_ha_cluster(cluster, get_enum_value, get_uuid_value, serialize_value) 
         parsed.setdefault(key, serialize_value(value))
 
     return parsed
+
+
+def _license_issue_id(entry: ConfigEntry) -> str:
+    """Repair issue ID for one config entry's license warning."""
+    return f"unsupported_license_{entry.entry_id}"
+
+
+def _check_license_support(hass: HomeAssistant, entry: ConfigEntry, data: dict | None) -> None:
+    """Warn when the server's license is outside what this integration supports.
+
+    Raised as a repair issue rather than only a log line, so it is visible without digging
+    through logs, and cleared automatically once the server reports a supported license.
+    Never blocks setup: a Community Edition server that works is not worth refusing.
+    """
+    license_info = (data or {}).get("license_info")
+    reason = unsupported_license_reason(license_info)
+    issue_id = _license_issue_id(entry)
+
+    if reason is None:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+        return
+
+    _LOGGER.warning(
+        "Veeam server %s reports license %s, which this integration does not support (%s). "
+        "Setup will continue, but entities may be missing or unreliable. Please include the "
+        "license edition when reporting problems",
+        entry.data.get(CONF_HOST, "unknown"),
+        describe_license(license_info),
+        reason,
+    )
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="unsupported_license",
+        translation_placeholders={
+            "host": str(entry.data.get(CONF_HOST, "unknown")),
+            "license": describe_license(license_info),
+        },
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -736,6 +781,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
+    # Runs on every setup, so a reload re-reports it and a newly licensed server clears it
+    _check_license_support(hass, entry, coordinator.data)
+
     entry.runtime_data = {
         "coordinator": coordinator,
         "veeam_client": veeam_client,
@@ -756,3 +804,12 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Clean up after a removed config entry.
+
+    Deleted here rather than on unload, which also runs on every reload — the warning would
+    otherwise disappear and come back on each restart.
+    """
+    ir.async_delete_issue(hass, DOMAIN, _license_issue_id(entry))

--- a/custom_components/veeam_br/diagnostics.py
+++ b/custom_components/veeam_br/diagnostics.py
@@ -7,6 +7,21 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .const import CONF_API_VERSION, DEFAULT_API_VERSION
+from .licensing import unsupported_license_reason
+
+
+def _veeam_br_version() -> str:
+    """Version of the installed veeam-br library, or why it could not be read."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("veeam-br")
+    except PackageNotFoundError:
+        return "not installed"
+    except Exception as err:  # noqa: BLE001 - diagnostics must never raise
+        return f"unknown ({err})"
+
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
@@ -25,6 +40,11 @@ async def async_get_config_entry_diagnostics(
             "domain": entry.domain,
             "title": entry.title,
             "unique_id": entry.unique_id,
+            # First questions in any bug report: which API revision, and which library
+            "api_version": entry.options.get(
+                CONF_API_VERSION, entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
+            ),
+            "veeam_br_version": _veeam_br_version(),
         },
         "coordinator": {
             "last_update_success": coordinator.last_update_success,
@@ -60,6 +80,8 @@ async def async_get_config_entry_diagnostics(
             "status": license_info.get("status"),
             "edition": license_info.get("edition"),
             "type": license_info.get("type"),
+            # Names the licensing limitation instead of leaving it to be inferred
+            "unsupported_reason": unsupported_license_reason(license_info),
         }
 
     # Add job summaries (without sensitive details)

--- a/custom_components/veeam_br/licensing.py
+++ b/custom_components/veeam_br/licensing.py
@@ -1,0 +1,68 @@
+"""Recognize Veeam licenses this integration does not support.
+
+Veeam Backup & Replication Community Edition, and a server with no license installed at
+all, are outside what this integration is tested against: entitlements differ, some
+endpoints answer differently or not at all, and the resulting failures look like integration
+bugs rather than licensing limits.
+
+Detection is a warning, never a block. A Community Edition server that works is not worth
+refusing, and the check is only as good as what the license endpoint reports — so it errs
+toward saying nothing when the answer is unclear.
+
+Kept free of Home Assistant imports so it can be tested directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# EInstalledLicenseEdition value for Community Edition
+COMMUNITY_EDITION = "community"
+
+# EInstalledLicenseType values that mean "not a paid license". "Free" is what Community
+# Edition reports; "Empty" is a server with no license installed, which runs as Community.
+UNLICENSED_TYPES = frozenset({"free", "empty"})
+
+# Reason codes, used as translation placeholders and log detail
+REASON_COMMUNITY_EDITION = "community_edition"
+REASON_NO_LICENSE = "no_license"
+
+
+def _normalize(value: Any) -> str:
+    """Lower-case a license field, tolerating None and non-strings."""
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower()
+
+
+def unsupported_license_reason(license_info: dict[str, Any] | None) -> str | None:
+    """Return why this license is unsupported, or None if it looks supported.
+
+    Returns REASON_COMMUNITY_EDITION or REASON_NO_LICENSE. An absent or unreadable license
+    returns None: the license endpoint failing is its own problem, already logged where it
+    happens, and guessing "unlicensed" from missing data would warn people wrongly.
+    """
+    if not license_info:
+        return None
+
+    edition = _normalize(license_info.get("edition"))
+    license_type = _normalize(license_info.get("type"))
+
+    if edition == COMMUNITY_EDITION:
+        return REASON_COMMUNITY_EDITION
+
+    if license_type in UNLICENSED_TYPES:
+        # "Empty" is specifically no license at all, which is worth naming separately
+        return REASON_NO_LICENSE if license_type == "empty" else REASON_COMMUNITY_EDITION
+
+    return None
+
+
+def describe_license(license_info: dict[str, Any] | None) -> str:
+    """Summarize a license for a log line, e.g. "Community/Free"."""
+    if not license_info:
+        return "unknown"
+
+    edition = license_info.get("edition") or "Unknown"
+    license_type = license_info.get("type") or "Unknown"
+    return f"{edition}/{license_type}"

--- a/custom_components/veeam_br/strings.json
+++ b/custom_components/veeam_br/strings.json
@@ -282,5 +282,11 @@
         "invalid": "Invalid"
       }
     }
+  },
+  "issues": {
+    "unsupported_license": {
+      "title": "Unsupported Veeam license on {host}",
+      "description": "The Veeam Backup & Replication server at **{host}** reports the license **{license}**.\n\nVeeam Community Edition, and servers with no license installed, are not supported by this integration: entitlements differ and some REST API endpoints answer differently or not at all, so entities may be missing or unreliable.\n\nThe integration keeps running — nothing is blocked. If you hit problems, please include this license edition in your bug report. Install a supported license, or remove the integration, to clear this warning."
+    }
   }
 }

--- a/custom_components/veeam_br/translations/en.json
+++ b/custom_components/veeam_br/translations/en.json
@@ -282,5 +282,11 @@
         "invalid": "Invalid"
       }
     }
+  },
+  "issues": {
+    "unsupported_license": {
+      "title": "Unsupported Veeam license on {host}",
+      "description": "The Veeam Backup & Replication server at **{host}** reports the license **{license}**.\n\nVeeam Community Edition, and servers with no license installed, are not supported by this integration: entitlements differ and some REST API endpoints answer differently or not at all, so entities may be missing or unreliable.\n\nThe integration keeps running — nothing is blocked. If you hit problems, please include this license edition in your bug report. Install a supported license, or remove the integration, to clear this warning."
+    }
   }
 }

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -1,0 +1,175 @@
+"""Tests for unsupported-license detection.
+
+licensing.py imports no Home Assistant modules, so it runs directly. The values here are the
+real EInstalledLicenseEdition and EInstalledLicenseType strings the API returns.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
+
+
+def _load_licensing():
+    """Load licensing.py standalone."""
+    spec = importlib.util.spec_from_file_location("veeam_br_licensing", COMPONENT / "licensing.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def license_info(edition="Enterprise", type_="Perpetual"):
+    """Shaped like coordinator.data["license_info"]."""
+    return {"status": "Valid", "edition": edition, "type": type_}
+
+
+# EInstalledLicenseEdition: Community, Enterprise, EnterprisePlus, Standard, Unspecified
+# EInstalledLicenseType: Empty, Evaluation, Free, NFR, Perpetual, Promo, Rental, Subscription
+
+
+@pytest.mark.parametrize(
+    "edition,type_",
+    [
+        ("Enterprise", "Perpetual"),
+        ("EnterprisePlus", "Subscription"),
+        ("Standard", "Rental"),
+        ("Enterprise", "Evaluation"),
+        ("EnterprisePlus", "NFR"),
+        ("Enterprise", "Promo"),
+    ],
+)
+def test_supported_licenses_are_not_flagged(edition, type_):
+    """Paid, evaluation and NFR licenses all entitle the endpoints this integration uses."""
+    licensing = _load_licensing()
+
+    assert licensing.unsupported_license_reason(license_info(edition, type_)) is None
+
+
+def test_community_edition_is_flagged():
+    licensing = _load_licensing()
+
+    reason = licensing.unsupported_license_reason(license_info("Community", "Free"))
+
+    assert reason == licensing.REASON_COMMUNITY_EDITION
+
+
+def test_free_type_is_flagged_even_if_the_edition_is_unclear():
+    """Some servers report the type but leave the edition Unspecified."""
+    licensing = _load_licensing()
+
+    reason = licensing.unsupported_license_reason(license_info("Unspecified", "Free"))
+
+    assert reason == licensing.REASON_COMMUNITY_EDITION
+
+
+def test_no_license_is_reported_separately():
+    """ "Empty" means nothing is installed, which is worth naming distinctly."""
+    licensing = _load_licensing()
+
+    reason = licensing.unsupported_license_reason(license_info("Unspecified", "Empty"))
+
+    assert reason == licensing.REASON_NO_LICENSE
+
+
+def test_edition_and_type_are_matched_case_insensitively():
+    """Casing is Veeam's to change; detection should not hinge on it."""
+    licensing = _load_licensing()
+
+    assert licensing.unsupported_license_reason(license_info("COMMUNITY", "free")) is not None
+    assert licensing.unsupported_license_reason(license_info(" community ", "Free")) is not None
+
+
+@pytest.mark.parametrize(
+    "info",
+    [None, {}, {"status": "Valid"}, {"edition": None, "type": None}, {"edition": 12, "type": []}],
+    ids=["none", "empty", "status-only", "null-fields", "wrong-types"],
+)
+def test_unreadable_license_is_not_flagged(info):
+    """Missing license data is its own failure, logged where it happens.
+
+    Guessing "unlicensed" from an absent license would warn people who simply hit an API
+    error, which is worse than staying quiet.
+    """
+    licensing = _load_licensing()
+
+    assert licensing.unsupported_license_reason(info) is None
+
+
+def test_describe_license_summarizes_for_a_log_line():
+    licensing = _load_licensing()
+
+    assert licensing.describe_license(license_info("Community", "Free")) == "Community/Free"
+    assert licensing.describe_license(None) == "unknown"
+    assert licensing.describe_license({}) == "unknown"
+    assert "Unknown" in licensing.describe_license({"edition": None, "type": None})
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_warning_is_raised_as_a_repair_issue_and_logged():
+    """A log line alone is invisible; repairs surface in the UI."""
+    content = (COMPONENT / "__init__.py").read_text(encoding="utf-8")
+
+    check = content[content.index("def _check_license_support") :]
+    check = check[: check.index("async def async_setup_entry")]
+
+    assert "ir.async_create_issue" in check, "should raise a repair issue"
+    assert "_LOGGER.warning" in check, "should also log, for reload visibility"
+    assert "IssueSeverity.WARNING" in check, "a warning, not an error: setup still works"
+    assert "ir.async_delete_issue" in check, "should clear once the license is supported"
+    assert "return False" not in check, "an unsupported license must not block setup"
+
+
+def test_license_is_checked_on_every_setup():
+    """Setup runs again on reload, which is how the warning reappears."""
+    content = (COMPONENT / "__init__.py").read_text(encoding="utf-8")
+
+    first_refresh = content.index("await coordinator.async_config_entry_first_refresh()")
+    check = content.index("_check_license_support(hass, entry, coordinator.data)")
+    forward = content.index("async_forward_entry_setups")
+
+    assert first_refresh < check < forward, (
+        "the check needs coordinator data, so it belongs after the first refresh and before "
+        "platforms are set up"
+    )
+
+
+def test_issue_is_cleared_when_the_entry_is_removed():
+    """A stale warning for a deleted entry would never go away on its own."""
+    content = (COMPONENT / "__init__.py").read_text(encoding="utf-8")
+
+    assert "async def async_remove_entry" in content
+    remove = content[content.index("async def async_remove_entry") :]
+    assert "ir.async_delete_issue" in remove
+
+    # Unload also runs on reload, so clearing there would make the warning flicker
+    unload = content[content.index("async def async_unload_entry") :]
+    unload = unload[: unload.index("async def async_remove_entry")]
+    assert "async_delete_issue" not in unload
+
+
+def test_repair_issue_text_exists_and_is_translated():
+    """An untranslated repair renders as a raw key in the UI."""
+    for name in ("strings.json", "translations/en.json"):
+        data = json.loads((COMPONENT / name).read_text(encoding="utf-8"))
+        issue = data["issues"]["unsupported_license"]
+
+        assert "{host}" in issue["title"]
+        assert "{license}" in issue["description"]
+        # The text should say it is not blocking, since the integration keeps running
+        assert "keeps running" in issue["description"]
+
+
+def test_diagnostics_report_what_a_bug_report_needs():
+    """The issue template points people at diagnostics, so it has to carry the basics."""
+    content = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+
+    assert '"api_version"' in content, "which API revision was in use"
+    assert "_veeam_br_version" in content, "which library version was installed"
+    assert "unsupported_reason" in content, "whether the license is a supported one"


### PR DESCRIPTION
Community Edition and unlicensed servers have different entitlements, and some REST endpoints answer differently or not at all — which surfaces as missing or unreliable entities that look like integration bugs. Name the cause instead of leaving it to be guessed.

The license edition is already polled for the License device, so detection costs no extra request. An unsupported edition raises a repair issue under Settings → Repairs and logs a warning; the check runs on every setup, so a reload re-reports it, and it clears itself once the server reports a supported license.

Deliberately a warning, not a block: a Community Edition server that works is not worth refusing. Detection also stays quiet when the license is unreadable — inferring "unlicensed" from a failed license call would warn people who merely hit an API error, which is worse than saying nothing.

Also, so that reports arrive with the facts that matter:

- add issue templates. The bug form asks for the VBR build, license edition, selected API version, integration and veeam-br versions, and HA version, and points at the diagnostics download first.
- add the selected API version, the installed veeam-br version and the license verdict to diagnostics, since the template now tells people to attach it.
- clear the repair issue on entry removal, not unload, or it would flicker on every reload.

The README claimed Community Edition "lacks REST API". That cannot be right — the edition is read *through* the REST API — so the wording now says untested and unsupported, which is what is actually true.