### PR TITLE
Name the working port when a connection fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ All devices and entities associated with this integration will be removed.
 - Verify the Veeam server is running and accessible from Home Assistant
 - Check that the REST API is enabled on the Veeam server
 - Confirm the hostname/IP and port are correct — 443 on Veeam B&R 13.1 and newer, 9419 on
-  older releases
+  older releases. If you get the port wrong, the setup form checks the other one and tells
+  you which it found
 - Ensure firewall rules allow traffic on the REST API port (443, or 9419 on older releases)
 - Try disabling SSL verification if using self-signed certificates
 

--- a/custom_components/veeam_br/config_flow.py
+++ b/custom_components/veeam_br/config_flow.py
@@ -104,13 +104,17 @@ async def async_find_working_port(data: dict[str, Any], configured_port: int) ->
     connect" is now quite often the wrong port rather than a wrong host or a firewall. Worth
     one extra probe to be able to say which.
     """
-    from veeam_br.discovery import DEFAULT_PORTS, detect_rest_api
-
-    others = [port for port in DEFAULT_PORTS if port != configured_port]
-    if not others:
-        return None
-
     try:
+        # Guarded with the probe itself: this runs inside validate_input's failure handler,
+        # so an ImportError escaping here would replace the real connection error with
+        # "unknown". The manifest floors veeam-br at 0.5.0, but a hand-installed older copy
+        # should degrade to the generic error, not a misleading one.
+        from veeam_br.discovery import DEFAULT_PORTS, detect_rest_api
+
+        others = [port for port in DEFAULT_PORTS if port != configured_port]
+        if not others:
+            return None
+
         endpoint = await detect_rest_api(
             data[CONF_HOST],
             ports=others,

--- a/custom_components/veeam_br/config_flow.py
+++ b/custom_components/veeam_br/config_flow.py
@@ -30,6 +30,17 @@ from .sdk_patches import patch_models as patch_null_values_in_models
 _LOGGER = logging.getLogger(__name__)
 
 
+class WrongPortError(ConnectionError):
+    """The configured port did not answer, but another REST API port did.
+
+    Carries the port that answered so the form can name it.
+    """
+
+    def __init__(self, port: int) -> None:
+        super().__init__(f"The REST API answered on port {port}, not the configured port")
+        self.port = port
+
+
 def _get_api_version_selector_config(
     preferred_version: str | None = None,
 ) -> tuple[list[str], str]:
@@ -84,6 +95,33 @@ async def async_resolve_api_version(data: dict[str, Any]) -> str:
 
     _LOGGER.info("Detected API version %s on %s", detected, data[CONF_HOST])
     return detected
+
+
+async def async_find_working_port(data: dict[str, Any], configured_port: int) -> int | None:
+    """Return another port the REST API answers on, or None.
+
+    Veeam B&R 13.1 moved the REST API to 443 and will eventually drop 9419, so "cannot
+    connect" is now quite often the wrong port rather than a wrong host or a firewall. Worth
+    one extra probe to be able to say which.
+    """
+    from veeam_br.discovery import DEFAULT_PORTS, detect_rest_api
+
+    others = [port for port in DEFAULT_PORTS if port != configured_port]
+    if not others:
+        return None
+
+    try:
+        endpoint = await detect_rest_api(
+            data[CONF_HOST],
+            ports=others,
+            versions=list(API_VERSIONS),
+            verify_ssl=data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+        )
+    except Exception as err:  # noqa: BLE001 - a failed probe just means no advice to give
+        _LOGGER.debug("Port probe failed: %s", err)
+        return None
+
+    return endpoint.port if endpoint else None
 
 
 def _load_veeam_br(api_version: str):
@@ -145,6 +183,15 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     except PermissionError:
         raise
     except Exception as err:
+        working_port = await async_find_working_port(data, data[CONF_PORT])
+        if working_port is not None:
+            _LOGGER.warning(
+                "Could not reach the Veeam REST API on %s:%s, but it answered on port %s",
+                data[CONF_HOST],
+                data[CONF_PORT],
+                working_port,
+            )
+            raise WrongPortError(working_port) from err
         raise ConnectionError(f"Failed to connect: {err}") from err
 
     return {"title": f"Veeam B&R ({data[CONF_HOST]})"}
@@ -163,6 +210,7 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle reconfiguration of the integration."""
         errors: dict[str, str] = {}
+        wrong_port: int | None = None
         reconf_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
@@ -180,6 +228,10 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await validate_input(self.hass, data)
             except PermissionError:
                 errors["base"] = "invalid_auth"
+            except WrongPortError as err:
+                # Subclasses ConnectionError, so it has to be caught before it
+                errors["base"] = "wrong_port"
+                wrong_port = err.port
             except ConnectionError:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -213,6 +265,7 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={
                 "host": reconf_entry.data.get(CONF_HOST),
+                "wrong_port": str(wrong_port or ""),
             },
         )
 
@@ -225,6 +278,7 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Confirm reauth dialog."""
         errors: dict[str, str] = {}
+        wrong_port: int | None = None
         reauth_entry = self._get_reauth_entry()
 
         if user_input is not None:
@@ -239,6 +293,10 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await validate_input(self.hass, data)
             except PermissionError:
                 errors["base"] = "invalid_auth"
+            except WrongPortError as err:
+                # Subclasses ConnectionError, so it has to be caught before it
+                errors["base"] = "wrong_port"
+                wrong_port = err.port
             except ConnectionError:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -264,11 +322,13 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={
                 "host": reauth_entry.data[CONF_HOST],
+                "wrong_port": str(wrong_port or ""),
             },
         )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}
+        wrong_port: int | None = None
 
         if user_input is not None:
             await self.async_set_unique_id(f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}")
@@ -278,6 +338,10 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await validate_input(self.hass, user_input)
             except PermissionError:
                 errors["base"] = "invalid_auth"
+            except WrongPortError as err:
+                # Subclasses ConnectionError, so it has to be caught before it
+                errors["base"] = "wrong_port"
+                wrong_port = err.port
             except ConnectionError:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -318,7 +382,12 @@ class VeeamBRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+            description_placeholders={"wrong_port": str(wrong_port or "")},
+        )
 
 
 class VeeamBROptionsFlow(config_entries.OptionsFlow):
@@ -326,6 +395,7 @@ class VeeamBROptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}
+        wrong_port: int | None = None
 
         if user_input is not None:
             test_data = {**self.config_entry.data, CONF_API_VERSION: user_input[CONF_API_VERSION]}
@@ -334,6 +404,10 @@ class VeeamBROptionsFlow(config_entries.OptionsFlow):
                 await validate_input(self.hass, test_data)
             except PermissionError:
                 errors["base"] = "invalid_auth"
+            except WrongPortError as err:
+                # Subclasses ConnectionError, so it has to be caught before it
+                errors["base"] = "wrong_port"
+                wrong_port = err.port
             except ConnectionError:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -375,4 +449,9 @@ class VeeamBROptionsFlow(config_entries.OptionsFlow):
             }
         )
 
-        return self.async_show_form(step_id="init", data_schema=options_schema, errors=errors)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=options_schema,
+            errors=errors,
+            description_placeholders={"wrong_port": str(wrong_port or "")},
+        )

--- a/custom_components/veeam_br/manifest.json
+++ b/custom_components/veeam_br/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Cenvora/ha-veeam-br/issues",
   "requirements": [
-    "veeam-br>=0.4.0,<1.0.0"
+    "veeam-br>=0.5.0,<1.0.0"
   ],
   "version": "0.5.0b1"
 }

--- a/custom_components/veeam_br/strings.json
+++ b/custom_components/veeam_br/strings.json
@@ -55,7 +55,8 @@
     "error": {
       "cannot_connect": "Failed to connect to Veeam server",
       "invalid_auth": "Invalid authentication credentials",
-      "unknown": "Unexpected error occurred"
+      "unknown": "Unexpected error occurred",
+      "wrong_port": "Could not connect on that port, but the Veeam REST API answered on port {wrong_port}. Veeam B&R 13.1 and newer serve the API on 443; older releases use 9419."
     },
     "abort": {
       "already_configured": "This Veeam server is already configured",
@@ -82,7 +83,8 @@
     "error": {
       "cannot_connect": "Failed to connect to Veeam server",
       "invalid_auth": "Invalid authentication credentials",
-      "unknown": "Unexpected error occurred"
+      "unknown": "Unexpected error occurred",
+      "wrong_port": "Could not connect on that port, but the Veeam REST API answered on port {wrong_port}. Veeam B&R 13.1 and newer serve the API on 443; older releases use 9419."
     }
   },
   "entity": {

--- a/custom_components/veeam_br/translations/en.json
+++ b/custom_components/veeam_br/translations/en.json
@@ -55,7 +55,8 @@
     "error": {
       "cannot_connect": "Failed to connect to Veeam server",
       "invalid_auth": "Invalid authentication credentials",
-      "unknown": "Unexpected error occurred"
+      "unknown": "Unexpected error occurred",
+      "wrong_port": "Could not connect on that port, but the Veeam REST API answered on port {wrong_port}. Veeam B&R 13.1 and newer serve the API on 443; older releases use 9419."
     },
     "abort": {
       "already_configured": "This Veeam server is already configured",
@@ -82,7 +83,8 @@
     "error": {
       "cannot_connect": "Failed to connect to Veeam server",
       "invalid_auth": "Invalid authentication credentials",
-      "unknown": "Unexpected error occurred"
+      "unknown": "Unexpected error occurred",
+      "wrong_port": "Could not connect on that port, but the Veeam REST API answered on port {wrong_port}. Veeam B&R 13.1 and newer serve the API on 443; older releases use 9419."
     }
   },
   "entity": {

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -631,11 +631,12 @@ def test_manifest_requires_a_recent_enough_veeam_br():
     requirement = next(r for r in manifest["requirements"] if r.startswith("veeam-br"))
 
     # Floors we depend on, newest first:
+    #   0.5.0 — veeam_br.discovery.detect_rest_api, used to name the port that answered
     #   0.4.0 — veeam_br.discovery.detect_api_version, used to auto-detect the version
     #   0.3.1 — VeeamClient recovers from a refused token refresh instead of leaving a
     #           dead session behind (issue #82)
     #   0.3.0 — first release shipping the v1_3_rev2 SDK
-    minimum = (0, 4, 0)
+    minimum = (0, 5, 0)
 
     match = re.search(r">=\s*(\d+)\.(\d+)\.(\d+)", requirement)
     assert match, f"veeam-br requirement should pin a minimum version, got {requirement}"

--- a/tests/test_port_detection.py
+++ b/tests/test_port_detection.py
@@ -116,6 +116,39 @@ def test_no_answer_gives_no_advice():
     assert asyncio.run(finder(data(), 443)) is None
 
 
+def test_an_older_library_degrades_to_the_generic_error():
+    """An ImportError escaping here would surface as "unknown" instead of the real error.
+
+    The manifest floors veeam-br at 0.5.0, but a hand-installed older copy has no
+    detect_rest_api, and the probe runs inside the connection-failure handler.
+    """
+    tree = ast.parse(CONFIG_FLOW_PATH.read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "async_find_working_port"
+    )
+
+    # A discovery module without the new names, exactly like veeam-br 0.4.0
+    sys.modules.setdefault("veeam_br", types.ModuleType("veeam_br"))
+    sys.modules["veeam_br.discovery"] = types.ModuleType("veeam_br.discovery")
+
+    namespace = {
+        "API_VERSIONS": SUPPORTED,
+        "CONF_HOST": "host",
+        "CONF_VERIFY_SSL": "verify_ssl",
+        "DEFAULT_VERIFY_SSL": True,
+        "_LOGGER": types.SimpleNamespace(debug=lambda *a, **k: None),
+        "Any": object,
+    }
+    exec(
+        compile(ast.Module(body=[func], type_ignores=[]), str(CONFIG_FLOW_PATH), "exec"),
+        namespace,
+    )
+
+    assert asyncio.run(namespace["async_find_working_port"](data(), 9419)) is None
+
+
 def test_a_failing_probe_is_not_fatal():
     """The probe is a nicety; it must not replace the real connection error."""
     finder = load_finder(raises=OSError("no route to host"))

--- a/tests/test_port_detection.py
+++ b/tests/test_port_detection.py
@@ -1,0 +1,179 @@
+"""Tests for telling the user which REST API port actually answered.
+
+Veeam B&R 13.1 moved the REST API to 443 and will eventually drop 9419, so a failed
+connection is now often the wrong port rather than a wrong host or a closed firewall. The
+probing itself lives in veeam_br.discovery; what matters here is that a wrong port produces
+port-specific advice instead of a bare "cannot connect".
+
+config_flow.py imports Home Assistant, so the helper is lifted out with ast and run against
+a stubbed veeam_br.discovery.
+"""
+
+import ast
+import asyncio
+import json
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
+CONFIG_FLOW_PATH = COMPONENT / "config_flow.py"
+
+SUPPORTED = {"1.2-rev1": "v1_2_rev1", "1.3-rev2": "v1_3_rev2"}
+
+
+def load_finder(endpoint=None, raises=None, record=None):
+    """Load async_find_working_port with veeam_br.discovery stubbed out."""
+    tree = ast.parse(CONFIG_FLOW_PATH.read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "async_find_working_port"
+    )
+
+    async def detect_rest_api(host, *, ports=None, versions=None, verify_ssl=True, **kwargs):
+        if record is not None:
+            record.update(host=host, ports=ports, versions=versions, verify_ssl=verify_ssl)
+        if raises is not None:
+            raise raises
+        return endpoint
+
+    discovery = types.ModuleType("veeam_br.discovery")
+    discovery.detect_rest_api = detect_rest_api
+    discovery.DEFAULT_PORTS = (443, 9419)
+    sys.modules.setdefault("veeam_br", types.ModuleType("veeam_br"))
+    sys.modules["veeam_br.discovery"] = discovery
+
+    namespace = {
+        "API_VERSIONS": SUPPORTED,
+        "CONF_HOST": "host",
+        "CONF_VERIFY_SSL": "verify_ssl",
+        "DEFAULT_VERIFY_SSL": True,
+        "_LOGGER": types.SimpleNamespace(debug=lambda *a, **k: None),
+        "Any": object,
+    }
+    exec(
+        compile(ast.Module(body=[func], type_ignores=[]), str(CONFIG_FLOW_PATH), "exec"),
+        namespace,
+    )
+    return namespace["async_find_working_port"]
+
+
+class Endpoint:
+    def __init__(self, port, api_version="1.3-rev2"):
+        self.port = port
+        self.api_version = api_version
+
+
+def data(**overrides):
+    entry = {"host": "vbr.example.com", "verify_ssl": True}
+    entry.update(overrides)
+    return entry
+
+
+def test_reports_the_port_that_answered():
+    finder = load_finder(endpoint=Endpoint(443))
+
+    assert asyncio.run(finder(data(), 9419)) == 443
+
+
+def test_only_the_other_ports_are_probed():
+    """Re-probing the port that just failed to connect would waste a round trip."""
+    record = {}
+    finder = load_finder(endpoint=Endpoint(443), record=record)
+
+    asyncio.run(finder(data(), 9419))
+
+    assert record["ports"] == [443], "should skip the port already known to fail"
+    assert record["host"] == "vbr.example.com"
+    assert record["versions"] == list(SUPPORTED)
+
+
+def test_a_custom_port_still_gets_both_well_known_ports_probed():
+    """Someone on a non-standard port may simply have the wrong number entirely."""
+    record = {}
+    finder = load_finder(endpoint=Endpoint(443), record=record)
+
+    assert asyncio.run(finder(data(), 8443)) == 443
+    assert record["ports"] == [443, 9419], "neither well-known port has been ruled out"
+
+
+def test_verify_ssl_is_passed_through():
+    record = {}
+    finder = load_finder(endpoint=Endpoint(9419), record=record)
+
+    asyncio.run(finder(data(verify_ssl=False), 443))
+
+    assert record["verify_ssl"] is False
+
+
+def test_no_answer_gives_no_advice():
+    """Nothing answering means the problem is not the port."""
+    finder = load_finder(endpoint=None)
+
+    assert asyncio.run(finder(data(), 443)) is None
+
+
+def test_a_failing_probe_is_not_fatal():
+    """The probe is a nicety; it must not replace the real connection error."""
+    finder = load_finder(raises=OSError("no route to host"))
+
+    assert asyncio.run(finder(data(), 443)) is None
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_port_is_caught_before_connection_error():
+    """WrongPortError subclasses ConnectionError, so ordering decides which wins."""
+    content = CONFIG_FLOW_PATH.read_text(encoding="utf-8")
+
+    assert "class WrongPortError(ConnectionError)" in content
+
+    # Every handler pair must test the subclass first, or the advice is never shown
+    assert (
+        content.count('errors["base"] = "wrong_port"') == 4
+    ), "all four flows (user, reconfigure, reauth, options) should surface it"
+
+    handlers = [
+        line.strip()
+        for line in content.splitlines()
+        if line.strip().startswith(("except WrongPortError", "except ConnectionError"))
+    ]
+    assert handlers, "no handlers found — has the flow been restructured?"
+    for wrong_port, connection in zip(handlers[::2], handlers[1::2]):
+        assert wrong_port.startswith("except WrongPortError"), (
+            f"ConnectionError is caught before WrongPortError ({connection}), which would "
+            "swallow the port advice"
+        )
+        assert connection.startswith("except ConnectionError")
+
+
+def test_every_form_supplies_the_placeholder():
+    """A message referencing {wrong_port} with no placeholder renders broken."""
+    content = CONFIG_FLOW_PATH.read_text(encoding="utf-8")
+
+    assert content.count('"wrong_port": str(wrong_port or "")') == 4
+
+
+def test_error_text_names_both_ports():
+    """The advice is only useful if it explains which port goes with which release."""
+    for name in ("strings.json", "translations/en.json"):
+        data = json.loads((COMPONENT / name).read_text(encoding="utf-8"))
+        for section in ("config", "options"):
+            message = data[section]["error"]["wrong_port"]
+            assert "{wrong_port}" in message
+            assert "443" in message
+            assert "9419" in message
+
+
+@pytest.mark.parametrize("section", ["config", "options"])
+def test_both_flows_can_render_the_error(section):
+    """The options flow resolves errors from its own section, not the config one."""
+    data = json.loads((COMPONENT / "strings.json").read_text(encoding="utf-8"))
+
+    assert "wrong_port" in data[section]["error"]


### PR DESCRIPTION
With 13.1 serving the REST API on 443, and 9419 due for removal, "Failed to connect to Veeam server" is now often just the wrong port — indistinguishable in the UI from a wrong host or a closed firewall.

On a connection failure the flow probes the other well-known port through veeam_br.discovery.detect_rest_api and, if the API answers there, reports which port to use instead of the generic error. The probe needs no credentials and costs one round trip on a path that has already failed. It stays advisory: a probe that finds nothing, or itself fails, leaves the original connection error untouched.

WrongPortError subclasses ConnectionError so existing callers keep working, which means it has to be caught first at all four flow sites — there is a test pinning that ordering, since getting it wrong silently swallows the advice.

The message is registered under both config.error and options.error, because the options flow resolves errors from its own section, and every form now supplies the {wrong_port} placeholder so the text cannot render half-formed.