### PR TITLE
Add automation blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project is an independent, open source project. It is not affiliated with, 
 
 ## Requirements
 
-- Home Assistant 2023.1.0 or newer
+- Home Assistant 2026.1 or newer
 - Veeam Backup & Replication server with the REST API enabled, on a supported license
   (see [Licensing](#licensing))
 
@@ -155,7 +155,8 @@ The integration creates devices for each monitored object (jobs, repositories, s
 Each backup job creates a device with the following sensors:
 
 - **Status Sensor**: `sensor.<job_name>_status`
-  - State: Current job status (`success`, `running`, `failed`, `warning`, `unknown`)
+  - State: What the job is doing (`Running`, `Inactive`, `Disabled`) — the pass/fail
+    outcome of the last run is on the **Last Result** sensor, not here
 - **Type Sensor**: `sensor.<job_name>_type`
   - State: Type of backup job
 - **Last Run Sensor**: `sensor.<job_name>_last_run`
@@ -228,6 +229,67 @@ automation:
             Secondary node lag was
             {{ states('sensor.vbr_ha_example_com_secondary_node_lag') }} MB.
 ```
+
+## Automation Blueprints
+
+Ready-made automations for the entities this integration creates. Each one asks you to pick
+the entities to watch and what to do about it — a notification, a script, anything Home
+Assistant can run — so they work with whatever notifier you already use.
+
+Click **Import blueprint**, then create automations from it under
+**Settings → Automations & scenes → Blueprints**.
+
+> [!NOTE]
+> Blueprints are not installed by HACS — Home Assistant has no mechanism for an integration to
+> ship them, and HACS has no blueprint category. The import links below fetch them from this
+> repository directly.
+
+### Backup job failed
+
+Notifies when a job's **Last Result** turns Failed (optionally Warning too).
+
+[![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FCenvora%2Fha-veeam-br%2Fmain%2Fblueprints%2Fautomation%2Fveeam_br%2Fjob_failed.yaml)
+
+<sub>Source: [`job_failed.yaml`](blueprints/automation/veeam_br/job_failed.yaml)</sub>
+
+### Repository running out of space
+
+Fires when a repository crosses a used-space threshold, with an optional recovery notification.
+
+[![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FCenvora%2Fha-veeam-br%2Fmain%2Fblueprints%2Fautomation%2Fveeam_br%2Frepository_space_low.yaml)
+
+<sub>Source: [`repository_space_low.yaml`](blueprints/automation/veeam_br/repository_space_low.yaml)</sub>
+
+### HA cluster failover or outage
+
+Fires when a High Availability cluster starts failing over or stops reporting itself online.
+
+[![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FCenvora%2Fha-veeam-br%2Fmain%2Fblueprints%2Fautomation%2Fveeam_br%2Fha_cluster_failover.yaml)
+
+<sub>Source: [`ha_cluster_failover.yaml`](blueprints/automation/veeam_br/ha_cluster_failover.yaml)</sub>
+
+### License expiring soon
+
+Daily reminder once a license or support contract is within N days of expiring.
+
+[![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FCenvora%2Fha-veeam-br%2Fmain%2Fblueprints%2Fautomation%2Fveeam_br%2Flicense_expiring.yaml)
+
+<sub>Source: [`license_expiring.yaml`](blueprints/automation/veeam_br/license_expiring.yaml)</sub>
+
+### Daily backup summary
+
+One digest a day: how many jobs succeeded, warned or failed, and which need attention.
+
+[![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FCenvora%2Fha-veeam-br%2Fmain%2Fblueprints%2Fautomation%2Fveeam_br%2Fdaily_backup_summary.yaml)
+
+<sub>Source: [`daily_backup_summary.yaml`](blueprints/automation/veeam_br/daily_backup_summary.yaml)</sub>
+
+### A note on which sensor to pick
+
+For job automations, use the **Last Result** sensor, not **Status**. Status reports what the
+job is doing (`Running`, `Inactive`, `Disabled`); the pass/fail outcome of the last run is on
+Last Result (`Success`, `Warning`, `Failed`, `None`). An automation keyed on Status would never
+see a failure.
 
 ## Example Automations
 

--- a/blueprints/automation/veeam_br/daily_backup_summary.yaml
+++ b/blueprints/automation/veeam_br/daily_backup_summary.yaml
@@ -1,0 +1,94 @@
+blueprint:
+  name: Veeam daily backup summary
+  description: >-
+    Send a once-a-day summary of your Veeam backup jobs: how many succeeded, warned or failed,
+    and which ones need attention.
+
+    Pick the **Last Result** sensors of the jobs to include. Optionally stay quiet on days when
+    everything succeeded, so the summary only arrives when it says something.
+  domain: automation
+  source_url: https://github.com/Cenvora/ha-veeam-br/blob/main/blueprints/automation/veeam_br/daily_backup_summary.yaml
+  author: Cenvora
+  input:
+    job_result_sensors:
+      name: Job Last Result sensors
+      description: The jobs to include in the summary.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - integration: veeam_br
+              domain: sensor
+    report_time:
+      name: Send at
+      default: "08:00:00"
+      selector:
+        time:
+    only_when_problems:
+      name: Only send when something needs attention
+      description: Skip the summary on days when every job succeeded.
+      default: false
+      selector:
+        boolean:
+    notification_action:
+      name: Notification action
+      description: >-
+        What to run. Available variables: `total`, `succeeded`, `warned`, `failed`,
+        `unknown_count`, `problem_jobs` (list of `{name, result}`), and ready-made `title` and
+        `message`.
+      selector:
+        action:
+
+mode: single
+
+triggers:
+  - trigger: time
+    at: !input report_time
+
+variables:
+  job_result_sensors: !input job_result_sensors
+  only_when_problems: !input only_when_problems
+  # ESessionResult is Failed / Warning / Success / None, compared lower-cased for safety
+  results: >-
+    {{ job_result_sensors | map('states') | map('lower') | list }}
+  total: "{{ job_result_sensors | count }}"
+  succeeded: "{{ results | select('eq', 'success') | list | count }}"
+  warned: "{{ results | select('eq', 'warning') | list | count }}"
+  failed: "{{ results | select('eq', 'failed') | list | count }}"
+  unknown_count: >-
+    {{ results | reject('in', ['success', 'warning', 'failed']) | list | count }}
+  problem_jobs: >-
+    {% set ns = namespace(items=[]) %}
+    {% for entity_id in job_result_sensors %}
+      {% set result = states(entity_id) %}
+      {% if result | lower in ['failed', 'warning'] %}
+        {% set ns.items = ns.items + [{
+             'name': device_attr(entity_id, 'name_by_user')
+                     or device_attr(entity_id, 'name')
+                     or entity_id,
+             'result': result,
+           }] %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.items }}
+  title: >-
+    {{ 'Veeam: all ' ~ total ~ ' jobs succeeded' if failed | int == 0 and warned | int == 0
+       else 'Veeam: ' ~ failed ~ ' failed, ' ~ warned ~ ' with warnings' }}
+  message: >-
+    {{ succeeded }} of {{ total }} jobs succeeded.
+    {%- if problem_jobs | count > 0 %}
+    Needs attention:
+    {% for job in problem_jobs %}
+    - {{ job.name }}: {{ job.result }}
+    {%- endfor %}
+    {%- endif %}
+    {%- if unknown_count | int > 0 %}
+    {{ unknown_count }} job(s) reported no result yet.
+    {%- endif %}
+
+conditions:
+  - condition: template
+    value_template: >-
+      {{ not only_when_problems or failed | int > 0 or warned | int > 0 }}
+
+actions: !input notification_action

--- a/blueprints/automation/veeam_br/ha_cluster_failover.yaml
+++ b/blueprints/automation/veeam_br/ha_cluster_failover.yaml
@@ -1,0 +1,72 @@
+blueprint:
+  name: Veeam HA cluster failover or outage
+  description: >-
+    Notify when a Veeam Backup & Replication High Availability cluster fails over, or goes
+    offline.
+
+    Requires a clustered Veeam B&R 13.1 server and the `1.3-rev2` API version — the cluster
+    device only exists then. A failover means the secondary node took over, so treat it as
+    something to look at even when backups keep running.
+  domain: automation
+  source_url: https://github.com/Cenvora/ha-veeam-br/blob/main/blueprints/automation/veeam_br/ha_cluster_failover.yaml
+  author: Cenvora
+  input:
+    failover_sensor:
+      name: Failover In Progress sensor
+      description: The cluster's "Failover In Progress" binary sensor.
+      selector:
+        entity:
+          filter:
+            - integration: veeam_br
+              domain: binary_sensor
+    online_sensor:
+      name: Cluster Online sensor
+      description: >-
+        Optional. The cluster's "Online" binary sensor, to also notify when the cluster stops
+        reporting itself online.
+      default: []
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - integration: veeam_br
+              domain: binary_sensor
+    notification_action:
+      name: Notification action
+      description: >-
+        What to run. Available variables: `cluster_name`, `event` (`failover` or `offline`),
+        and ready-made `title` and `message`.
+      selector:
+        action:
+
+mode: queued
+max: 10
+
+triggers:
+  - trigger: state
+    entity_id: !input failover_sensor
+    from: "off"
+    to: "on"
+    id: failover
+  - trigger: state
+    entity_id: !input online_sensor
+    from: "on"
+    to: "off"
+    id: offline
+
+variables:
+  event: "{{ trigger.id }}"
+  cluster_name: >-
+    {{ device_attr(trigger.entity_id, 'name_by_user')
+       or device_attr(trigger.entity_id, 'name')
+       or 'Veeam HA cluster' }}
+  title: >-
+    {{ 'Veeam HA cluster failing over: ' ~ cluster_name
+       if event == 'failover'
+       else 'Veeam HA cluster offline: ' ~ cluster_name }}
+  message: >-
+    {{ 'A failover is in progress on ' ~ cluster_name ~ '. The secondary node is taking over.'
+       if event == 'failover'
+       else cluster_name ~ ' is no longer reporting itself online.' }}
+
+actions: !input notification_action

--- a/blueprints/automation/veeam_br/job_failed.yaml
+++ b/blueprints/automation/veeam_br/job_failed.yaml
@@ -1,0 +1,70 @@
+blueprint:
+  name: Veeam backup job failed
+  description: >-
+    Notify when a Veeam backup job finishes with a failure, and optionally on a warning too.
+
+    Pick the **Last Result** sensors of the jobs you care about — not *Status*. Status reports
+    what the job is doing (running, inactive, disabled); the pass/fail outcome of the last run
+    lives in Last Result.
+  domain: automation
+  source_url: https://github.com/Cenvora/ha-veeam-br/blob/main/blueprints/automation/veeam_br/job_failed.yaml
+  author: Cenvora
+  input:
+    job_result_sensors:
+      name: Job Last Result sensors
+      description: One or more Veeam job "Last Result" sensors to watch.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - integration: veeam_br
+              domain: sensor
+    include_warnings:
+      name: Also notify on warnings
+      description: >-
+        Veeam reports a run that completed with problems as a warning rather than a failure.
+      default: false
+      selector:
+        boolean:
+    notification_action:
+      name: Notification action
+      description: >-
+        What to run when a job fails. These variables are available: `job_name`,
+        `job_result`, `job_entity_id`, and ready-made `title` and `message`.
+      selector:
+        action:
+
+# One automation instance can see several jobs fail in the same polling cycle
+mode: queued
+max: 25
+
+triggers:
+  - trigger: state
+    entity_id: !input job_result_sensors
+
+variables:
+  include_warnings: !input include_warnings
+  # ESessionResult is "Failed", "Warning", "Success" or "None". Compared lower-cased because
+  # the Veeam API has shipped different casing for other enums between revisions.
+  bad_results: "{{ ['failed', 'warning'] if include_warnings else ['failed'] }}"
+  job_result: "{{ trigger.to_state.state }}"
+  job_entity_id: "{{ trigger.entity_id }}"
+  # Each job is its own device, so the device name is the job name
+  job_name: >-
+    {{ device_attr(trigger.entity_id, 'name_by_user')
+       or device_attr(trigger.entity_id, 'name')
+       or trigger.to_state.name | replace(' Last Result', '') }}
+  title: "Veeam backup failed: {{ job_name }}"
+  message: "Veeam job {{ job_name }} finished with result {{ job_result }}."
+
+conditions:
+  - condition: template
+    value_template: "{{ job_result | lower in bad_results }}"
+  # Skip the transition out of unknown/unavailable after a restart or reload, which would
+  # otherwise re-notify about a failure that was already reported
+  - condition: template
+    value_template: >-
+      {{ trigger.from_state is not none
+         and trigger.from_state.state | lower not in ['unknown', 'unavailable'] }}
+
+actions: !input notification_action

--- a/blueprints/automation/veeam_br/license_expiring.yaml
+++ b/blueprints/automation/veeam_br/license_expiring.yaml
@@ -1,0 +1,95 @@
+blueprint:
+  name: Veeam license expiring soon
+  description: >-
+    Notify daily once a Veeam license — or its support contract — is within a chosen number of
+    days of expiring.
+
+    Checks once a day at a time you choose rather than reacting to a state change, so the
+    reminder keeps arriving until the license is renewed. Perpetual licenses report no
+    expiration date and are simply skipped.
+  domain: automation
+  source_url: https://github.com/Cenvora/ha-veeam-br/blob/main/blueprints/automation/veeam_br/license_expiring.yaml
+  author: Cenvora
+  input:
+    expiry_sensors:
+      name: Expiration sensors
+      description: >-
+        The license "Expiration Date" sensor, the "Support Expiration Date" sensor, or both.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - integration: veeam_br
+              domain: sensor
+              device_class: timestamp
+    days_before:
+      name: Warn this many days ahead
+      default: 30
+      selector:
+        number:
+          min: 1
+          max: 365
+          unit_of_measurement: days
+          mode: box
+    check_time:
+      name: Check at
+      description: Time of day to check.
+      default: "09:00:00"
+      selector:
+        time:
+    notification_action:
+      name: Notification action
+      description: >-
+        What to run while a license is expiring. Available variables: `expiring` (a list of
+        `{name, entity_id, days_left, expires}` mappings), `soonest_days_left`, and ready-made
+        `title` and `message`.
+      selector:
+        action:
+
+mode: single
+
+triggers:
+  - trigger: time
+    at: !input check_time
+
+variables:
+  days_before: !input days_before
+  expiry_sensors: !input expiry_sensors
+  # A perpetual license has no expiry date, so its sensor is unknown/unavailable — skip those
+  # rather than treating an unparseable date as "expiring now"
+  expiring: >-
+    {% set ns = namespace(items=[]) %}
+    {% for entity_id in expiry_sensors %}
+      {% set value = states(entity_id) %}
+      {% if value not in ['unknown', 'unavailable', 'none', ''] %}
+        {% set expires = as_datetime(value) %}
+        {% if expires is not none %}
+          {% set days_left = ((expires - now()).total_seconds() / 86400) | round(0, 'floor') | int %}
+          {% if days_left <= days_before %}
+            {% set ns.items = ns.items + [{
+                 'name': state_attr(entity_id, 'friendly_name') or entity_id,
+                 'entity_id': entity_id,
+                 'days_left': days_left,
+                 'expires': expires.isoformat(),
+               }] %}
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.items }}
+  soonest_days_left: >-
+    {{ expiring | map(attribute='days_left') | list | min if expiring | count > 0 else none }}
+  title: >-
+    {{ 'Veeam license expires today' if soonest_days_left is not none and soonest_days_left <= 0
+       else 'Veeam license expires in ' ~ soonest_days_left ~ ' days' }}
+  message: >-
+    {% for item in expiring %}
+    {{ item.name }}: {{ 'expired' if item.days_left < 0 else item.days_left ~ ' day(s) left' }}
+    ({{ as_timestamp(item.expires) | timestamp_custom('%Y-%m-%d') }}){{ '\n' if not loop.last }}
+    {% endfor %}
+
+conditions:
+  - condition: template
+    value_template: "{{ expiring | count > 0 }}"
+
+actions: !input notification_action

--- a/blueprints/automation/veeam_br/repository_space_low.yaml
+++ b/blueprints/automation/veeam_br/repository_space_low.yaml
@@ -1,0 +1,98 @@
+blueprint:
+  name: Veeam repository running out of space
+  description: >-
+    Notify when a Veeam backup repository crosses a used-space threshold, and again when it
+    recovers.
+
+    Pick the **Used Percentage** sensors of the repositories you want to watch. Scale-out
+    repositories report per-extent, so watch the extents rather than the SOBR.
+  domain: automation
+  source_url: https://github.com/Cenvora/ha-veeam-br/blob/main/blueprints/automation/veeam_br/repository_space_low.yaml
+  author: Cenvora
+  input:
+    repository_sensors:
+      name: Repository Used Percentage sensors
+      description: One or more Veeam repository "Used Percentage" sensors.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - integration: veeam_br
+              domain: sensor
+    threshold:
+      name: Used space threshold
+      description: Notify once a repository is at least this full.
+      default: 85
+      selector:
+        number:
+          min: 50
+          max: 99
+          unit_of_measurement: "%"
+          mode: slider
+    sustained_for:
+      name: Sustained for
+      description: >-
+        How long the repository must stay above the threshold before notifying. Useful because
+        a repository can briefly spike while a job is writing.
+      default:
+        minutes: 15
+      selector:
+        duration:
+    notification_action:
+      name: Notification action
+      description: >-
+        What to run when the threshold is crossed. Available variables: `repository_name`,
+        `used_percent`, `threshold`, `repository_entity_id`, and ready-made `title` and
+        `message`.
+      selector:
+        action:
+    recovery_action:
+      name: Recovery action
+      description: >-
+        Optional. What to run when the repository drops back below the threshold. The same
+        variables are available.
+      default: []
+      selector:
+        action:
+
+mode: queued
+max: 25
+
+triggers:
+  - trigger: numeric_state
+    entity_id: !input repository_sensors
+    above: !input threshold
+    for: !input sustained_for
+    id: above
+  - trigger: numeric_state
+    entity_id: !input repository_sensors
+    below: !input threshold
+    id: recovered
+
+variables:
+  threshold: !input threshold
+  repository_entity_id: "{{ trigger.entity_id }}"
+  used_percent: "{{ trigger.to_state.state }}"
+  # Each repository is its own device, so the device name is the repository name
+  repository_name: >-
+    {{ device_attr(trigger.entity_id, 'name_by_user')
+       or device_attr(trigger.entity_id, 'name')
+       or trigger.to_state.name | replace(' Used Percentage', '') }}
+  title: >-
+    {{ 'Veeam repository low on space: ' ~ repository_name
+       if trigger.id == 'above'
+       else 'Veeam repository space recovered: ' ~ repository_name }}
+  message: >-
+    {{ repository_name }} is {{ used_percent }}% full
+    {{ '(threshold ' ~ threshold ~ '%)' if trigger.id == 'above' else '— back under ' ~ threshold ~ '%' }}.
+
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: above
+        sequence: !input notification_action
+      - conditions:
+          - condition: trigger
+            id: recovered
+        sequence: !input recovery_action

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Veeam Backup & Replication",
   "render_readme": true,
-  "homeassistant": "2023.1.0"
+  "homeassistant": "2026.1.0"
 }

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1,0 +1,206 @@
+"""Validation for the shipped automation blueprints.
+
+Home Assistant is not installed in this environment, so these tests check the things that
+actually break a blueprint in the wild and that no YAML linter would catch: an `!input` that
+was never declared, a declared input nothing uses (a UI field that does nothing), a
+`source_url` that does not match where the file really lives (which breaks the import link),
+and selectors pointing at a different integration.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+BLUEPRINT_DIR = REPO / "blueprints" / "automation" / "veeam_br"
+REPO_SLUG = "Cenvora/ha-veeam-br"
+
+
+class BlueprintLoader(yaml.SafeLoader):
+    """SafeLoader that understands Home Assistant's blueprint tags."""
+
+
+class Input:
+    """Stands in for an !input tag so the document can be walked."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f"!input {self.name}"
+
+
+BlueprintLoader.add_constructor("!input", lambda loader, node: Input(loader.construct_scalar(node)))
+
+
+def blueprint_files():
+    return sorted(BLUEPRINT_DIR.glob("*.yaml"))
+
+
+def load(path):
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=BlueprintLoader)
+
+
+def walk(node):
+    """Yield every value in a nested structure."""
+    yield node
+    if isinstance(node, dict):
+        for value in node.values():
+            yield from walk(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from walk(value)
+
+
+def used_inputs(document):
+    return {node.name for node in walk(document) if isinstance(node, Input)}
+
+
+def test_blueprints_exist():
+    assert blueprint_files(), "no blueprints found — has the directory moved?"
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_has_required_metadata(path):
+    """Missing metadata makes a blueprint unimportable or anonymous in the UI."""
+    document = load(path)
+    meta = document.get("blueprint")
+
+    assert meta, "no blueprint: block"
+    assert meta.get("domain") == "automation"
+    assert meta.get("name"), "needs a name for the blueprint list"
+    assert meta.get("description"), "needs a description explaining which entities to pick"
+    assert meta.get("input"), "an automation blueprint with no inputs is just an automation"
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_source_url_matches_the_file_location(path):
+    """The import link is built from source_url; a stale one imports the wrong file."""
+    document = load(path)
+    source_url = document["blueprint"].get("source_url")
+
+    assert source_url, "needs source_url so Home Assistant can offer re-import"
+    expected = f"https://github.com/{REPO_SLUG}/blob/main/" f"{path.relative_to(REPO).as_posix()}"
+    assert source_url == expected, f"expected {expected}"
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_every_input_is_declared(path):
+    """An !input with no declaration fails at import time with a schema error."""
+    document = load(path)
+    declared = set(document["blueprint"]["input"])
+
+    undeclared = used_inputs(document) - declared
+    assert not undeclared, f"used but not declared: {sorted(undeclared)}"
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_every_declared_input_is_used(path):
+    """A declared input nothing references is a UI field that silently does nothing."""
+    document = load(path)
+    declared = set(document["blueprint"]["input"])
+
+    unused = declared - used_inputs(document)
+    assert not unused, f"declared but never used: {sorted(unused)}"
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_is_a_runnable_automation(path):
+    """Uses the current plural keys, which the 2026.1 floor guarantees."""
+    document = load(path)
+
+    assert "triggers" in document, "no triggers"
+    assert "actions" in document, "no actions"
+    assert "trigger" not in document, "singular trigger: is the pre-2024.10 spelling"
+    assert "action" not in document, "singular action: is the pre-2024.10 spelling"
+    assert "condition" not in document, "singular condition: is the pre-2024.10 spelling"
+
+    for entry in document["triggers"]:
+        assert "trigger" in entry, f"trigger entry missing its platform: {entry}"
+        assert "platform" not in entry, "platform: is the pre-2024.10 spelling"
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_entity_selectors_target_this_integration(path):
+    """A selector without the filter lists every entity in the user's system."""
+    document = load(path)
+
+    for name, spec in document["blueprint"]["input"].items():
+        selector = spec.get("selector", {})
+        if "entity" not in selector:
+            continue
+        filters = (selector["entity"] or {}).get("filter")
+        assert filters, f"{name}: entity selector should filter to this integration"
+        integrations = {f.get("integration") for f in filters}
+        assert integrations == {"veeam_br"}, f"{name}: filters {integrations}"
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_notification_action_is_an_action_selector(path):
+    """Hard-coding a notify service would tie the blueprint to one setup."""
+    document = load(path)
+    inputs = document["blueprint"]["input"]
+
+    assert "notification_action" in inputs, "every blueprint should let the user choose"
+    assert "action" in inputs["notification_action"]["selector"]
+
+
+@pytest.mark.parametrize("path", blueprint_files(), ids=lambda p: p.name)
+def test_optional_inputs_have_defaults(path):
+    """An input with no default is mandatory; that has to be deliberate."""
+    document = load(path)
+
+    mandatory = [
+        name for name, spec in document["blueprint"]["input"].items() if "default" not in spec
+    ]
+    # The entities to watch and the action to run are the only things a user must supply
+    allowed = {
+        "job_result_sensors",
+        "repository_sensors",
+        "expiry_sensors",
+        "failover_sensor",
+        "notification_action",
+    }
+    assert set(mandatory) <= allowed, f"unexpectedly mandatory: {sorted(set(mandatory) - allowed)}"
+
+
+def test_job_blueprints_watch_last_result_not_status():
+    """Status never reports failure — EJobStatus is running/inactive/disabled.
+
+    The pass/fail outcome is on the Last Result sensor (ESessionResult). A blueprint keyed on
+    Status would never fire.
+    """
+    for name in ("job_failed.yaml", "daily_backup_summary.yaml"):
+        text = (BLUEPRINT_DIR / name).read_text(encoding="utf-8")
+        assert "Last Result" in text, f"{name} should direct users to the Last Result sensor"
+
+
+def test_result_matching_is_case_insensitive():
+    """1.2-rev1 lower-cases some enums where 1.3-rev* capitalizes them."""
+    for name in ("job_failed.yaml", "daily_backup_summary.yaml"):
+        text = (BLUEPRINT_DIR / name).read_text(encoding="utf-8")
+        assert (
+            "| lower" in text or "map('lower')" in text
+        ), f"{name} should compare results case-insensitively across API revisions"
+
+
+def test_readme_links_every_blueprint():
+    """A blueprint nobody can find is a blueprint nobody uses."""
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+
+    for path in blueprint_files():
+        assert path.name in readme, f"{path.name} is not mentioned in the README"
+        assert "blueprint_url" in readme, "README should offer one-click import links"
+
+
+def test_hacs_declares_the_supported_home_assistant_version():
+    """HACS blocks installation on older cores using this value."""
+    hacs = json.loads((REPO / "hacs.json").read_text(encoding="utf-8"))
+
+    major, minor = hacs["homeassistant"].split(".")[:2]
+    assert (int(major), int(minor)) >= (2026, 1), (
+        "blueprints use the plural trigger/action keys, which need 2024.10+; the project "
+        "targets 2026.1+"
+    )


### PR DESCRIPTION
Five blueprints for the entities this integration creates: job failed, repository running out of space, HA cluster failover or outage, license expiring soon, and a daily backup summary. Each takes the entities to watch plus an action selector, so they work with whatever notifier the user already has rather than hard-coding notify.notify.

Home Assistant has no mechanism for an integration to ship blueprints — DomainBlueprints.async_populate only copies from the automation and script integrations themselves — and HACS has no blueprint category. So they live in this repo and the README carries My Home Assistant import links, which is the path HA's importer supports (github.com/blob, raw, gist and forum URLs).

Two details that decide whether these actually fire:

- They watch the Last Result sensor, not Status. EJobStatus is running/inactive/disabled and never reports failure; the outcome of a run is ESessionResult on Last Result. A blueprint keyed on Status would sit silent forever. The README said Status showed success/failed/warning, which was wrong, and is now fixed.
- Results are compared lower-cased, because 1.2-rev1 lower-cases enum values where 1.3-rev* capitalizes them.

tests/test_blueprints.py checks what a YAML linter cannot: every !input is declared, every declared input is used (an unused one is a UI field that does nothing), source_url matches the file's real path so the import link resolves, entity selectors are filtered to this integration rather than listing every entity in the system, and the plural trigger/action keys are used throughout.

Raises the Home Assistant floor to 2026.1 in hacs.json and the README, which is what allows the current plural syntax.