### PR TITLE
Add license usage sensors, and tell "no HA cluster" from a real error

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ The integration also creates devices for:
 - **Repositories**: Each repository device has sensors for type, capacity, free space, used space, online status, etc., and a rescan button.
 - **Scale-Out Backup Repositories (SOBRs)**: Each SOBR device has sensors for description, extent count, and buttons for each extent to enable/disable sealed mode and maintenance mode.
 - **Server**: Server device has sensors for build version, platform, database info, etc.
-- **License**: License device has sensors for status, edition, expiration dates, etc.
+- **License**: License device has sensors for status, edition, expiration dates, and — on
+  instance-based licences — instances licensed, instances used and percentage used, with the
+  per-workload-type breakdown as attributes.
 - **High Availability Cluster**: on a clustered Veeam B&R 13.1 server (API `1.3-rev2`), a
   cluster device with online and failover-in-progress sensors, cluster endpoint and last-online
   diagnostics, per-node replication state, Patroni role and replication lag, plus switchover

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -175,6 +175,76 @@ def _license_text(license_data, field: str, default: str = "Unknown") -> str:
     return text or default
 
 
+def _number_or_none(obj, name: str):
+    """Read a numeric field, mapping UNSET and non-numbers to None."""
+    value = getattr(obj, name, None)
+    if _is_unset(value) or isinstance(value, bool):
+        return None
+    return value if isinstance(value, (int, float)) else None
+
+
+def _license_instance_usage(license_data) -> dict:
+    """Instance-based licensing figures, or an empty dict for other license types.
+
+    Socket and capacity licenses count different units, so instance sensors would be
+    meaningless for them and are not created at all.
+    """
+    summary = getattr(license_data, "instance_license_summary", None)
+    if _is_unset(summary):
+        return {}
+
+    licensed = _number_or_none(summary, "licensed_instances_number")
+    used = _number_or_none(summary, "used_instances_number")
+
+    usage = {
+        "package": _license_text(summary, "package", default=None),
+        "instances_licensed": licensed,
+        "instances_used": used,
+        "instances_new": _number_or_none(summary, "new_instances_number"),
+        "instances_rental": _number_or_none(summary, "rental_instances_number"),
+    }
+
+    if licensed and used is not None:
+        usage["instances_used_percent"] = round(used / licensed * 100, 1)
+
+    # The per-type breakdown is small and stable. The full workload list is not — a large
+    # estate has thousands of entries, which have no business in a state attribute.
+    objects = getattr(summary, "objects", None)
+    if not _is_unset(objects):
+        usage["instance_objects"] = [
+            {
+                "type": _license_text(item, "type_", default="Unknown"),
+                "count": _number_or_none(item, "count"),
+                "used": _number_or_none(item, "used_instances_number"),
+            }
+            for item in objects
+        ]
+
+    workload = getattr(summary, "workload", None)
+    if not _is_unset(workload):
+        usage["instance_workload_count"] = len(workload)
+
+    return usage
+
+
+def _cluster_absent_reason(result) -> tuple[bool, str]:
+    """Whether an HA cluster response means "not clustered", and what to say about it.
+
+    A server with no cluster answers 400 with an Error saying exactly that, which is the
+    normal case and not worth a warning. But 401, 403 and 500 come back as an Error too, and
+    treating those as "no cluster" would hide a real failure behind a debug line.
+    """
+    message = _license_text(result, "message", default="")
+    extras = getattr(result, "additional_properties", {}) or {}
+    status_code = extras.get("status")
+
+    if status_code == 400 or "not configured" in message.lower():
+        return True, message or "no cluster configured"
+
+    detail = f"HTTP {status_code}: {message}" if status_code else message
+    return False, detail or type(result).__name__
+
+
 def _license_issue_id(entry: ConfigEntry) -> str:
     """Repair issue ID for one config entry's license warning."""
     return f"unsupported_license_{entry.entry_id}"
@@ -479,6 +549,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         "free_agent_instance_consumption_enabled": getattr(
                             license_data, "free_agent_instance_consumption_enabled", False
                         ),
+                        **_license_instance_usage(license_data),
                     }
             except (AttributeError, KeyError, TypeError) as err:
                 _LOGGER.warning("Failed to parse license info: %s", err)
@@ -764,12 +835,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     )
                     cluster = await veeam_client.call(ha_api.get_high_availability_cluster)
 
-                    if cluster is None or not hasattr(cluster, "cluster_endpoint"):
-                        # None, or an Error model: this server is not clustered
-                        _LOGGER.debug(
-                            "No HA cluster reported by this server (%s)",
-                            type(cluster).__name__,
-                        )
+                    if cluster is None:
+                        _LOGGER.debug("HA cluster endpoint returned no data")
+                    elif not hasattr(cluster, "cluster_endpoint"):
+                        # An Error model. "Not configured" is the normal answer from an
+                        # unclustered server; anything else is a failure worth reporting.
+                        unclustered, detail = _cluster_absent_reason(cluster)
+                        if unclustered:
+                            _LOGGER.debug("No HA cluster on this server: %s", detail)
+                        else:
+                            _LOGGER.warning("Could not read the HA cluster: %s", detail)
                     else:
                         ha_cluster = _parse_ha_cluster(
                             cluster, get_enum_value, get_uuid_value, serialize_value

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -175,6 +175,18 @@ async def async_setup_entry(
                     VeeamLicenseCloudConnectSensor(coordinator, entry),
                 ]
             )
+
+            # Instance-based licences only: a socket or capacity licence counts other units
+            if coordinator.data["license_info"].get("instances_licensed") is not None:
+                new_entities.extend(
+                    [
+                        VeeamLicenseInstancesLicensedSensor(coordinator, entry),
+                        VeeamLicenseInstancesUsedSensor(coordinator, entry),
+                    ]
+                )
+                if coordinator.data["license_info"].get("instances_used_percent") is not None:
+                    new_entities.append(VeeamLicenseInstancesUsedPercentSensor(coordinator, entry))
+
             license_added = True
 
         # ---- HA CLUSTER SENSORS (once) - clustered servers on 1.3-rev2 and newer only ----
@@ -1697,3 +1709,107 @@ class VeeamHAClusterNodeLagSensor(VeeamHAClusterNodeSensorBase):
     @property
     def icon(self) -> str:
         return "mdi:timer-sand"
+
+
+# ===========================
+# LICENSE USAGE (instance-based licensing)
+#
+# Only created when the server reports an instanceLicenseSummary. Socket and capacity
+# licenses count different units, so instance sensors would be meaningless for them.
+# ===========================
+
+
+class VeeamLicenseInstancesLicensedSensor(VeeamLicenseBaseSensor):
+    """Sensor for the number of licensed instances."""
+
+    _attr_native_unit_of_measurement = "instances"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_license_instances_licensed"
+        self._attr_name = "Instances Licensed"
+
+    @property
+    def native_value(self):
+        license_info = self._license_info()
+        return license_info.get("instances_licensed") if license_info else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        license_info = self._license_info() or {}
+        return {
+            "package": license_info.get("package"),
+            "new_instances": license_info.get("instances_new"),
+            "rental_instances": license_info.get("instances_rental"),
+        }
+
+    @property
+    def icon(self) -> str:
+        return "mdi:counter"
+
+
+class VeeamLicenseInstancesUsedSensor(VeeamLicenseBaseSensor):
+    """Sensor for the number of licensed instances in use."""
+
+    _attr_native_unit_of_measurement = "instances"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_license_instances_used"
+        self._attr_name = "Instances Used"
+
+    @property
+    def native_value(self):
+        license_info = self._license_info()
+        return license_info.get("instances_used") if license_info else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The per-type breakdown, which is small and stable.
+
+        The full workload list is deliberately not exposed: a large estate has thousands of
+        entries, and state attributes are recorded on every update.
+        """
+        license_info = self._license_info() or {}
+        attributes: dict[str, Any] = {
+            "protected_workloads": license_info.get("instance_workload_count"),
+        }
+        for item in license_info.get("instance_objects") or []:
+            name = (item.get("type") or "unknown").lower().replace(" ", "_")
+            attributes[name] = item.get("used")
+        return attributes
+
+    @property
+    def icon(self) -> str:
+        return "mdi:counter"
+
+
+class VeeamLicenseInstancesUsedPercentSensor(VeeamLicenseBaseSensor):
+    """Sensor for how much of the instance licence is consumed."""
+
+    _attr_native_unit_of_measurement = "%"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 1
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_license_instances_used_percent"
+        self._attr_name = "Instances Used Percentage"
+
+    @property
+    def native_value(self):
+        license_info = self._license_info()
+        return license_info.get("instances_used_percent") if license_info else None
+
+    @property
+    def icon(self) -> str:
+        value = self.native_value
+        if value is None:
+            return "mdi:gauge"
+        if value >= 90:
+            return "mdi:gauge-full"
+        if value >= 70:
+            return "mdi:gauge-low"
+        return "mdi:gauge"

--- a/tests/test_ha_cluster.py
+++ b/tests/test_ha_cluster.py
@@ -252,15 +252,28 @@ def test_cluster_fetch_is_version_guarded():
 
 
 def test_unclustered_server_is_not_an_error():
-    """Most servers are not clustered; that must not log a warning every poll."""
+    """Most servers are not clustered; that must not log a warning every poll.
+
+    The behaviour itself — which Error means "no cluster" and which means a real failure —
+    is tested in test_license_dates.py against the server's actual 400 payload. This checks
+    the two are wired to the right log levels.
+    """
     content = INIT_PATH.read_text(encoding="utf-8")
 
-    marker = "No HA cluster reported by this server"
+    marker = "No HA cluster on this server"
     assert marker in content
     line_start = content.rindex("_LOGGER.", 0, content.index(marker))
     assert content[line_start:].startswith(
         "_LOGGER.debug"
     ), "an unclustered server should be a debug message, not a warning"
+
+    # An auth or server error arrives as the same Error model and must not be buried
+    failure = "Could not read the HA cluster"
+    assert failure in content
+    line_start = content.rindex("_LOGGER.", 0, content.index(failure))
+    assert content[line_start:].startswith(
+        "_LOGGER.warning"
+    ), "401/403/500 come back as an Error too, and should be reported"
 
 
 def test_failover_button_is_disabled_by_default():

--- a/tests/test_license_dates.py
+++ b/tests/test_license_dates.py
@@ -197,3 +197,163 @@ def test_the_schema_change_is_documented():
     docstring = source[source.index("def _license_datetime") :][:900]
 
     assert "1.2-rev1" in docstring and "1.3-rev" in docstring
+
+
+# ---------------------------------------------------------------------------
+# Instance licensing figures
+#
+# Fixtures mirror a real 13.1 NFR response: 20 licensed, 11 used, a per-type breakdown, and a
+# workload list naming each protected object.
+# ---------------------------------------------------------------------------
+
+USAGE_HELPERS = ("_is_unset", "_license_text", "_number_or_none", "_license_instance_usage")
+
+
+def _lift(names, wanted):
+    """Execute a subset of __init__.py's module-level functions and return one of them."""
+    tree = ast.parse(INIT_PATH.read_text(encoding="utf-8"))
+    nodes = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in names]
+    assert len(nodes) == len(names), f"missing helpers, found {[n.name for n in nodes]}"
+
+    namespace = {}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(INIT_PATH), "exec"), namespace)
+    return namespace[wanted]
+
+
+@pytest.fixture(name="usage", scope="module")
+def usage_fixture():
+    return _lift(USAGE_HELPERS, "_license_instance_usage")
+
+
+def instance_license(**overrides):
+    summary = Summary(
+        package="Suite",
+        licensed_instances_number=20,
+        used_instances_number=11,
+        new_instances_number=0,
+        rental_instances_number=0,
+        expiration_date=EXPIRES,
+        objects=[
+            Summary(type_="Virtual Machines", count=10, multiplier=1, used_instances_number=10),
+            Summary(type_="Servers", count=1, multiplier=1, used_instances_number=1),
+            Summary(type_="File Shares (500 GB)", count=0, multiplier=1, used_instances_number=0),
+        ],
+        workload=[Summary(name=f"vm-{n}") for n in range(13)],
+    )
+    summary.__dict__.update(overrides)
+    return License(instance_license_summary=summary)
+
+
+def test_reads_the_licensed_and_used_counts(usage):
+    figures = usage(instance_license())
+
+    assert figures["instances_licensed"] == 20
+    assert figures["instances_used"] == 11
+    assert figures["package"] == "Suite"
+
+
+def test_computes_the_used_percentage(usage):
+    assert usage(instance_license())["instances_used_percent"] == 55.0
+
+
+def test_percentage_is_omitted_when_the_licence_count_is_zero(usage):
+    """An unlimited or malformed licence must not divide by zero."""
+    figures = usage(instance_license(licensed_instances_number=0))
+
+    assert "instances_used_percent" not in figures
+    assert figures["instances_licensed"] == 0
+
+
+def test_percentage_is_omitted_when_usage_is_unknown(usage):
+    figures = usage(instance_license(used_instances_number=UNSET))
+
+    assert figures["instances_used"] is None
+    assert "instances_used_percent" not in figures
+
+
+def test_keeps_the_per_type_breakdown(usage):
+    objects = usage(instance_license())["instance_objects"]
+
+    assert {o["type"] for o in objects} == {
+        "Virtual Machines",
+        "Servers",
+        "File Shares (500 GB)",
+    }
+    assert next(o for o in objects if o["type"] == "Virtual Machines")["used"] == 10
+
+
+def test_counts_workloads_without_listing_them(usage):
+    """A large estate has thousands of workloads, and attributes are recorded every update."""
+    figures = usage(instance_license())
+
+    assert figures["instance_workload_count"] == 13
+    assert "workload" not in figures, "the full list must not reach state attributes"
+
+
+def test_a_socket_or_capacity_licence_reports_no_instance_figures(usage):
+    assert usage(License(socket_license_summary=Summary(licensed_sockets_number=4))) == {}
+    assert usage(License()) == {}
+
+
+def test_missing_optional_fields_do_not_break_parsing(usage):
+    figures = usage(License(instance_license_summary=Summary(licensed_instances_number=5)))
+
+    assert figures["instances_licensed"] == 5
+    assert figures["instances_used"] is None
+    assert "instance_objects" not in figures
+    assert "instance_workload_count" not in figures
+
+
+def test_usage_sensors_are_only_created_for_instance_licences():
+    """A socket licence would otherwise get instance sensors that read unknown forever."""
+    sensor_source = (INIT_PATH.parent / "sensor.py").read_text(encoding="utf-8")
+
+    assert 'get("instances_licensed") is not None' in sensor_source
+    assert 'get("instances_used_percent") is not None' in sensor_source
+
+
+# ---------------------------------------------------------------------------
+# "No HA cluster" versus a real cluster failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="cluster_reason", scope="module")
+def cluster_reason_fixture():
+    return _lift(("_is_unset", "_license_text", "_cluster_absent_reason"), "_cluster_absent_reason")
+
+
+class ApiError:
+    """Shaped like the generated Error model, whose extras carry the HTTP status."""
+
+    def __init__(self, message, status=None, error_code="UnknownError"):
+        self.message = message
+        self.error_code = error_code
+        self.additional_properties = {"status": status} if status else {}
+
+
+NOT_CONFIGURED = (
+    "High Availability cluster is not configured. Configure a cluster before using this operation."
+)
+
+
+def test_a_400_not_configured_is_normal(cluster_reason):
+    """The real response from an unclustered server — it must not warn on every poll."""
+    unclustered, detail = cluster_reason(ApiError(NOT_CONFIGURED, status=400))
+
+    assert unclustered is True
+    assert "not configured" in detail
+
+
+def test_not_configured_without_a_status_is_still_recognised(cluster_reason):
+    unclustered, _ = cluster_reason(ApiError(NOT_CONFIGURED))
+
+    assert unclustered is True
+
+
+@pytest.mark.parametrize("status", [401, 403, 500])
+def test_other_errors_are_reported_not_hidden(cluster_reason, status):
+    """Reading an auth or server failure as "no cluster" would bury it in debug."""
+    unclustered, detail = cluster_reason(ApiError("Unauthorized", status=status))
+
+    assert unclustered is False
+    assert str(status) in detail


### PR DESCRIPTION
Instance-based licences report how many instances are licensed and how many are in use, which is the number a backup admin actually watches. Three sensors on the existing License device: Instances Licensed, Instances Used, and Instances Used Percentage.

They are created only when the server reports an instanceLicenseSummary — a socket or capacity licence counts different units, and instance sensors would read unknown forever.

The per-type breakdown (Virtual Machines, Servers, File Shares…) goes on Instances Used as attributes, along with a count of protected workloads. The full workload list deliberately does not: a large estate has thousands of entries, and state attributes are written to the recorder on every update.

Separately, a flaw this exposed. A server with no HA cluster answers 400 with an Error saying "High Availability cluster is not configured", which we correctly logged at debug — but 401, 403 and 500 return the same Error model, so a genuine auth or server failure was being reported as "no cluster" at debug level and effectively hidden. Those now log a warning with the server's own message, while the not-configured case stays quiet.

Builds on the license-date fix, whose _is_unset and _license_text this reuses.