### PR TITLE
Show readable labels instead of API identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,26 @@ If you report a problem, please include the license edition — the diagnostics 
 (⋮ → *Download diagnostics*) contains it, along with the API version and library version, and
 no credentials.
 
+## Entity States
+
+Values that the REST API reports as identifiers are shown as readable labels:
+`EnterprisePlus` becomes *Enterprise Plus*, `ProxmoxBackupJob` becomes *Proxmox Backup Job*,
+`WinLocal` becomes *Windows (local)*, and `inactive` becomes *Inactive*. Job status is lower
+case on API 1.2-rev1 and capitalised on 1.3-rev*, so labels are matched case-insensitively and
+render identically whichever server answers.
+
+Every sensor whose state is a label also carries the untouched API value as a `raw_value`
+attribute, so automations that need to match exactly have something stable:
+
+```yaml
+{{ state_attr('sensor.nightly_vms_last_result', 'raw_value') == 'Failed' }}
+```
+
+> [!NOTE]
+> This changed in 0.6.0. Templates comparing against raw identifiers — `== 'EnterprisePlus'`,
+> `== 'inactive'` — should switch to `raw_value`, or compare case-insensitively against the
+> label. The shipped blueprints already compare lower-cased and were unaffected.
+
 ## Known Limitations
 
 - **Veeam Community Edition / unlicensed servers**: Not supported. The integration detects

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     UPDATE_INTERVAL,
     check_api_feature_availability,
 )
+from .display import humanize
 from .licensing import describe_license, unsupported_license_reason
 from .sdk_patches import patch_models as patch_null_values_in_models
 
@@ -59,8 +60,10 @@ def _parse_ha_cluster_node(node, get_enum_value, get_uuid_value) -> dict | None:
         "name": getattr(node, "name", None) or "Unknown",
         "ip_address": getattr(node, "ip_address", None) or None,
         "fqdn": getattr(node, "fqdn", None) or None,
-        "role": get_enum_value(getattr(node, "role", None)),
-        "state": get_enum_value(getattr(node, "state", None)),
+        "role": humanize(get_enum_value(getattr(node, "role", None)), "Unknown"),
+        "role_raw": get_enum_value(getattr(node, "role", None)),
+        "state": humanize(get_enum_value(getattr(node, "state", None)), "Unknown"),
+        "state_raw": get_enum_value(getattr(node, "state", None)),
         "timeline": getattr(node, "timeline", None) or None,
         "lag_mb": lag_mb if isinstance(lag_mb, (int, float)) else None,
         "external_endpoint": external_endpoint,
@@ -451,9 +454,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                             job_dict = {
                                 "id": job_id,
                                 "name": job.name or "Unknown",
-                                "type": get_enum_value(job.type_),
-                                "status": get_enum_value(job.status),
-                                "last_result": get_enum_value(job.last_result),
+                                "type": humanize(get_enum_value(job.type_), "Unknown"),
+                                "type_raw": get_enum_value(job.type_),
+                                "status": humanize(get_enum_value(job.status), "Unknown"),
+                                "status_raw": get_enum_value(job.status),
+                                "last_result": humanize(get_enum_value(job.last_result), "Unknown"),
+                                "last_result_raw": get_enum_value(job.last_result),
                                 "last_run": get_datetime_value(job.last_run),
                                 "next_run": get_datetime_value(job.next_run),
                             }
@@ -533,11 +539,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         return str(attr)
 
                     license_info = {
-                        "status": get_license_enum_attr(license_data, "status"),
-                        "edition": get_license_enum_attr(license_data, "edition"),
-                        "type": get_license_enum_attr(
-                            license_data, "type_"
-                        ),  # Note: type_ with underscore
+                        "status": humanize(
+                            get_license_enum_attr(license_data, "status"), "Unknown"
+                        ),
+                        "status_raw": get_license_enum_attr(license_data, "status"),
+                        "edition": humanize(
+                            get_license_enum_attr(license_data, "edition"), "Unknown"
+                        ),
+                        "edition_raw": get_license_enum_attr(license_data, "edition"),
+                        # Note: type_ with underscore
+                        "type": humanize(get_license_enum_attr(license_data, "type_"), "Unknown"),
+                        "type_raw": get_license_enum_attr(license_data, "type_"),
                         "expiration_date": _license_datetime(license_data, "expiration_date"),
                         "support_expiration_date": _license_datetime(
                             license_data, "support_expiration_date"
@@ -630,7 +642,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                                 "id": get_uuid_value(repo.id),
                                 "name": repo.name or "Unknown",
                                 "description": repo.description or "",
-                                "type": get_enum_value(repo.type_),
+                                "type": humanize(get_enum_value(repo.type_), "Unknown"),
+                                "type_raw": get_enum_value(repo.type_),
                                 "unique_id": (
                                     repo.unique_id if repo.unique_id is not UNSET else None
                                 ),

--- a/custom_components/veeam_br/display.py
+++ b/custom_components/veeam_br/display.py
@@ -1,0 +1,136 @@
+"""Turn Veeam's API values into something readable.
+
+The REST API reports enum values as identifiers — ``EnterprisePlus``, ``ProxmoxBackupJob``,
+``WinLocal``, ``inactive`` — which is fine for code and poor on a dashboard.
+
+Two rules, in order:
+
+1. An explicit override, for values where splitting the identifier gives the wrong answer:
+   ``WinLocal`` is "Windows (local)", not "Win Local".
+2. Otherwise split the identifier into words and title-case them, keeping runs of capitals
+   intact so ``NutanixAHVBackupJob`` becomes "Nutanix AHV Backup Job".
+
+Matching is case-insensitive on purpose. Veeam is not consistent between revisions — job
+status is lower case in 1.2-rev1 and capitalised in 1.3-rev* — and a display layer that
+renders the same state two different ways depending on the server is worse than useless.
+
+The raw value is kept alongside the label wherever this is used, so automations that need to
+match exactly have something stable to match on.
+
+Kept free of Home Assistant imports so it can be tested directly.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Words that should never be title-cased into something silly
+ACRONYMS = frozenset(
+    {
+        "AD",
+        "AHV",
+        "API",
+        "AWS",
+        "CDP",
+        "DNS",
+        "GB",
+        "HA",
+        "ID",
+        "IP",
+        "NAS",
+        "NFR",
+        "NFS",
+        "S3",
+        "SMB",
+        "SQL",
+        "SSH",
+        "TB",
+        "VM",
+        "VMS",
+        "VPC",
+    }
+)
+
+# Values whose split would read badly, or that have an established spelling
+OVERRIDES = {
+    # License editions and types
+    "enterpriseplus": "Enterprise Plus",
+    "nfr": "NFR",
+    "empty": "No license",
+    "unspecified": "Unspecified",
+    # Session results. "None" on its own reads as a missing value rather than "never ran"
+    "none": "No result",
+    # Repository types
+    "winlocal": "Windows (local)",
+    "linuxlocal": "Linux (local)",
+    "linuxhardened": "Linux (hardened)",
+    "smbshare": "SMB share",
+    "nfsshare": "NFS share",
+    "amazons3": "Amazon S3",
+    "amazons3external": "Amazon S3 (external)",
+    "amazons3glacier": "Amazon S3 Glacier",
+    "azureblob": "Azure Blob",
+    "azureblobexternal": "Azure Blob (external)",
+    "azurearchive": "Azure Archive",
+    "azuredatabox": "Azure Data Box",
+    "googlecloud": "Google Cloud",
+    "s3compatible": "S3 compatible",
+    "s3compatible2nas": "S3 compatible (NAS)",
+    "ddboost": "Dell Data Domain (DD Boost)",
+    "hpestoreonce": "HPE StoreOnce",
+    "wasabicloud": "Wasabi Cloud",
+    "ibmcloud": "IBM Cloud",
+    "scaleout": "Scale-out",
+    "cifs": "SMB share",
+    "nfs": "NFS share",
+    # Patroni node roles and states, from the HA cluster
+    "standbyleader": "Standby leader",
+    "syncstandby": "Sync standby",
+    "initdbfailed": "Initialisation failed",
+    "inarchiverecovery": "In archive recovery",
+    "creatingreplica": "Creating replica",
+    "initializingnewcluster": "Initialising new cluster",
+    "startfailed": "Start failed",
+    "stopfailed": "Stop failed",
+    "restartfailed": "Restart failed",
+}
+
+# Split on underscores, hyphens, spaces, lower→upper boundaries, and the end of a run of
+# capitals that is followed by a normal word (so "AHVBackup" splits as "AHV" + "Backup")
+_SPLIT = re.compile(r"[_\-\s]+|(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+def _word(word: str) -> str:
+    if word.upper() in ACRONYMS:
+        return word.upper()
+    if word.isupper() and len(word) > 1:
+        # An unlisted all-caps run is probably still an acronym
+        return word
+    return word[:1].upper() + word[1:]
+
+
+def humanize(value: Any, default: str | None = None) -> str | None:
+    """Return a readable label for an API value.
+
+    Anything that is not a non-empty string — None, the library's UNSET sentinel, a number —
+    returns ``default``, so callers can decide between "Unknown" and leaving a sensor empty.
+    """
+    if not isinstance(value, str):
+        return default
+
+    text = value.strip()
+    if not text:
+        return default
+
+    # Looked up with separators removed too, so "scale-out" and "ScaleOut" agree
+    lowered = text.lower()
+    override = OVERRIDES.get(lowered) or OVERRIDES.get(re.sub(r"[_\-\s]+", "", lowered))
+    if override:
+        return override
+
+    words = [word for word in _SPLIT.split(text) if word]
+    if not words:
+        return default
+
+    return " ".join(_word(word) for word in words)

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -443,6 +443,12 @@ class VeeamJobStatusSensor(VeeamJobBaseSensor):
             return "mdi:close-circle"
         return "mdi:cloud-sync"
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The unprettified API value, for automations that match exactly."""
+        data = self._job()
+        return {"raw_value": data.get("status_raw") if data else None}
+
 
 class VeeamJobTypeSensor(VeeamJobBaseSensor):
     """Sensor for Veeam Job Type."""
@@ -461,6 +467,12 @@ class VeeamJobTypeSensor(VeeamJobBaseSensor):
     @property
     def icon(self) -> str:
         return "mdi:file-tree"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The unprettified API value, for automations that match exactly."""
+        data = self._job()
+        return {"raw_value": data.get("type_raw") if data else None}
 
 
 class VeeamJobLastRunSensor(VeeamJobBaseSensor):
@@ -529,10 +541,15 @@ class VeeamJobLastResultSensor(VeeamJobBaseSensor):
             return "mdi:close-circle"
         return "mdi:help-circle"
 
+    # ===========================
+    # SERVER INFO SENSORS (single device)
+    # ===========================
 
-# ===========================
-# SERVER INFO SENSORS (single device)
-# ===========================
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The unprettified API value, for automations that match exactly."""
+        data = self._job()
+        return {"raw_value": data.get("last_result_raw") if data else None}
 
 
 class VeeamServerBaseSensor(CoordinatorEntity, SensorEntity):
@@ -806,6 +823,12 @@ class VeeamLicenseStatusSensor(VeeamLicenseBaseSensor):
             return "mdi:license-off"
         return "mdi:license"
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The unprettified API value, for automations that match exactly."""
+        data = self._license_info()
+        return {"raw_value": data.get("status_raw") if data else None}
+
 
 class VeeamLicenseEditionSensor(VeeamLicenseBaseSensor):
     """Sensor for Veeam License Edition."""
@@ -825,6 +848,12 @@ class VeeamLicenseEditionSensor(VeeamLicenseBaseSensor):
     def icon(self) -> str:
         return "mdi:certificate"
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The unprettified API value, for automations that match exactly."""
+        data = self._license_info()
+        return {"raw_value": data.get("edition_raw") if data else None}
+
 
 class VeeamLicenseTypeSensor(VeeamLicenseBaseSensor):
     """Sensor for Veeam License Type."""
@@ -843,6 +872,12 @@ class VeeamLicenseTypeSensor(VeeamLicenseBaseSensor):
     @property
     def icon(self) -> str:
         return "mdi:file-document"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The unprettified API value, for automations that match exactly."""
+        data = self._license_info()
+        return {"raw_value": data.get("type_raw") if data else None}
 
 
 class VeeamLicenseExpirationSensor(VeeamLicenseBaseSensor):
@@ -1029,6 +1064,12 @@ class VeeamRepositoryTypeSensor(VeeamRepositoryBaseSensor):
         if "scale" in repo_type or "sobr" in repo_type:
             return "mdi:server-plus"
         return "mdi:database"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """The unprettified API value, for automations that match exactly."""
+        data = self._repository()
+        return {"raw_value": data.get("type_raw") if data else None}
 
 
 class VeeamRepositoryDescriptionSensor(VeeamRepositoryBaseSensor):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,181 @@
+"""Tests for turning Veeam's API values into readable labels.
+
+display.py imports no Home Assistant modules, so it runs directly. The inputs below are real
+values from the generated enums (EJobType, ERepositoryType, EInstalledLicenseEdition,
+EJobStatus, ESessionResult, EHaPatroniNodeState) rather than invented ones.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
+
+
+def _load_display():
+    spec = importlib.util.spec_from_file_location("veeam_br_display", COMPONENT / "display.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(name="humanize", scope="module")
+def humanize_fixture():
+    return _load_display().humanize
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Job types, including the ones 13.1 added
+        ("Backup", "Backup"),
+        ("BackupCopy", "Backup Copy"),
+        ("ProxmoxBackupJob", "Proxmox Backup Job"),
+        ("NutanixAHVBackupJob", "Nutanix AHV Backup Job"),
+        ("HyperVBackup", "Hyper V Backup"),
+        ("EntraIDTenantBackup", "Entra ID Tenant Backup"),
+        ("CloudBackupAWS", "Cloud Backup AWS"),
+        ("WindowsAgentBackupFailoverCluster", "Windows Agent Backup Failover Cluster"),
+        # License editions and types
+        ("EnterprisePlus", "Enterprise Plus"),
+        ("Enterprise", "Enterprise"),
+        ("NFR", "NFR"),
+        ("Perpetual", "Perpetual"),
+        ("Subscription", "Subscription"),
+        # Node roles and states from the HA cluster
+        ("StandbyLeader", "Standby leader"),
+        ("SyncStandby", "Sync standby"),
+        ("Streaming", "Streaming"),
+        ("InitdbFailed", "Initialisation failed"),
+    ],
+)
+def test_reads_like_english(humanize, value, expected):
+    assert humanize(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("WinLocal", "Windows (local)"),
+        ("LinuxLocal", "Linux (local)"),
+        ("LinuxHardened", "Linux (hardened)"),
+        ("SmbShare", "SMB share"),
+        ("AmazonS3", "Amazon S3"),
+        ("AzureBlob", "Azure Blob"),
+        ("S3Compatible", "S3 compatible"),
+        ("DDBoost", "Dell Data Domain (DD Boost)"),
+        ("HPEStoreOnce", "HPE StoreOnce"),
+    ],
+)
+def test_overrides_win_where_splitting_would_read_badly(humanize, value, expected):
+    """ "WinLocal" splits to "Win Local", which is not what anyone calls it."""
+    assert humanize(value) == expected
+
+
+@pytest.mark.parametrize("status", ["running", "Running", " running ", "Running "])
+def test_casing_does_not_change_the_label(humanize, status):
+    """Job status is lower case on 1.2-rev1 and capitalised on 1.3-rev*.
+
+    Rendering the same state differently depending on which server answered would be worse
+    than leaving it raw.
+    """
+    assert humanize(status) == "Running"
+
+
+@pytest.mark.parametrize(
+    "result,expected",
+    [("Success", "Success"), ("failed", "Failed"), ("Warning", "Warning")],
+)
+def test_session_results(humanize, result, expected):
+    assert humanize(result) == expected
+
+
+def test_none_result_says_what_it_means(humanize):
+    """ESessionResult "None" means the job has no result yet, not a missing value."""
+    assert humanize("None") == "No result"
+
+
+def test_empty_license_says_what_it_means(humanize):
+    """EInstalledLicenseType "Empty" means no license is installed."""
+    assert humanize("Empty") == "No license"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "   ", 12, 0, True, [], {}],
+    ids=["none", "empty", "whitespace", "int", "zero", "bool", "list", "dict"],
+)
+def test_non_values_fall_back_to_the_default(humanize, value):
+    assert humanize(value) is None
+    assert humanize(value, "Unknown") == "Unknown"
+
+
+def test_unknown_values_still_get_a_label(humanize):
+    """A value from a future API revision must not come out blank."""
+    assert humanize("SomeFutureBackupKind") == "Some Future Backup Kind"
+    assert humanize("XYZBackup") == "XYZ Backup"
+
+
+def test_unlisted_all_caps_runs_are_left_alone(humanize):
+    """Safer than title-casing: an unknown run of capitals is usually an acronym.
+
+    Veeam does not send fully upper-cased values, so this only affects hypotheticals.
+    """
+    assert humanize("SOBR") == "SOBR"
+    assert humanize("VBRBackup") == "VBR Backup"
+
+
+def test_snake_and_kebab_case_are_handled(humanize):
+    assert humanize("backup_copy") == "Backup Copy"
+    assert humanize("scale-out") == "Scale-out"
+
+
+def test_acronyms_are_not_title_cased(humanize):
+    display = _load_display()
+
+    for acronym in ("AWS", "SQL", "AHV", "NFR", "VM"):
+        assert acronym in display.ACRONYMS
+        assert humanize(acronym) == acronym
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_raw_values_are_kept_alongside_the_labels():
+    """Prettifying changes sensor states, so exact matching needs somewhere to go."""
+    init_source = (COMPONENT / "__init__.py").read_text(encoding="utf-8")
+
+    for key in (
+        "status_raw",
+        "type_raw",
+        "last_result_raw",
+        "edition_raw",
+        "role_raw",
+        "state_raw",
+    ):
+        assert f'"{key}"' in init_source, f"{key} should be stored next to its label"
+
+
+def test_prettified_sensors_expose_the_raw_value():
+    sensor_source = (COMPONENT / "sensor.py").read_text(encoding="utf-8")
+
+    assert (
+        sensor_source.count('"raw_value"') >= 7
+    ), "each sensor whose state is now a label should expose the API value as an attribute"
+
+
+def test_blueprints_still_match_after_prettifying():
+    """The blueprints compare lower-cased, so Success/success both work — keep it that way."""
+    blueprints = Path(__file__).parent.parent / "blueprints" / "automation" / "veeam_br"
+
+    for name in ("job_failed.yaml", "daily_backup_summary.yaml"):
+        text = (blueprints / name).read_text(encoding="utf-8")
+        assert "| lower" in text or "map('lower')" in text
+
+        # A label is a single word for results, so no blueprint should match on a raw enum
+        # identifier that prettifying would have split
+        assert "EnterprisePlus" not in text
+        assert "BackupCopy" not in text

--- a/tests/test_ha_cluster.py
+++ b/tests/test_ha_cluster.py
@@ -8,6 +8,7 @@ installed, which this repo's test environment does not have.
 
 import ast
 from datetime import datetime, timezone
+import importlib.util
 from pathlib import Path
 import re
 
@@ -43,9 +44,17 @@ def helpers_fixture():
     ]
     assert len(wanted) == len(HELPERS), f"expected {HELPERS} in __init__.py, found {wanted}"
 
+    # display.py is Home Assistant free, so the real humanize() is used rather than a stub —
+    # the parsed labels are what the sensors actually receive
+    display_path = INIT_PATH.parent / "display.py"
+    display_spec = importlib.util.spec_from_file_location("veeam_br_display", display_path)
+    display = importlib.util.module_from_spec(display_spec)
+    display_spec.loader.exec_module(display)
+
     namespace = {
         "dt_util": type("dt_util", (), {"parse_datetime": staticmethod(_parse_datetime)}),
         "timezone": timezone,
+        "humanize": display.humanize,
     }
     exec(compile(ast.Module(body=wanted, type_ignores=[]), str(INIT_PATH), "exec"), namespace)
     return namespace
@@ -134,8 +143,12 @@ def test_parses_a_healthy_cluster(helpers):
     assert parsed["cluster_dns_name"] == "vbr-ha.example.com"
     assert parsed["is_online"] is True
     assert parsed["is_failover_in_progress"] is False
+    # Roles are labels now, with the API value kept alongside for exact matching
     assert parsed["primary"]["role"] == "Leader"
-    assert parsed["secondary"]["role"] == "SyncStandby"
+    assert parsed["primary"]["role_raw"] == "Leader"
+    assert parsed["secondary"]["role"] == "Sync standby"
+    assert parsed["secondary"]["role_raw"] == "SyncStandby"
+    assert parsed["secondary"]["state"] == "Streaming"
     assert parsed["secondary"]["lag_mb"] == 12
 
 


### PR DESCRIPTION
Job types, repository types, license editions and types, statuses, results and Patroni node roles were rendered exactly as the REST API spells them: EnterprisePlus, ProxmoxBackupJob, WinLocal, inactive. display.py turns those into Enterprise Plus, Proxmox Backup Job, Windows (local) and Inactive.

Two rules, in order: an explicit override where splitting the identifier reads badly — WinLocal is "Windows (local)", not "Win Local" — otherwise split the identifier and title-case it, keeping runs of capitals intact so NutanixAHVBackupJob becomes "Nutanix AHV Backup Job". Overrides are looked up with separators removed, so scale-out, scale_out and ScaleOut agree.

Matching is deliberately case-insensitive. Job status is lower case on 1.2-rev1 and capitalised on 1.3-rev*, and rendering the same state two ways depending on which server answered would be worse than leaving it raw. Anything unrecognised still gets a label rather than coming out blank, so a job type added in a future revision reads correctly without a code change.

Prettifying changes sensor states, so every affected sensor now exposes the untouched API value as a raw_value attribute for templates that must match exactly. The shipped blueprints already compare lower-cased and are unaffected; there is a test pinning that.