### PR TITLE
Stop reloads re-triggering repository space alerts

### DIFF
--- a/blueprints/automation/veeam_br/ha_cluster_failover.yaml
+++ b/blueprints/automation/veeam_br/ha_cluster_failover.yaml
@@ -43,6 +43,8 @@ mode: queued
 max: 10
 
 triggers:
+  # from/to are both pinned deliberately: a reload takes these sensors through unavailable,
+  # and "unavailable -> on" does not match "off -> on", so a restart cannot re-alert
   - trigger: state
     entity_id: !input failover_sensor
     from: "off"

--- a/blueprints/automation/veeam_br/repository_space_low.yaml
+++ b/blueprints/automation/veeam_br/repository_space_low.yaml
@@ -6,6 +6,9 @@ blueprint:
 
     Pick the **Used Percentage** sensors of the repositories you want to watch. Scale-out
     repositories report per-extent, so watch the extents rather than the SOBR.
+
+    Reloading the integration or restarting Home Assistant will not re-notify about a
+    repository that was already over the threshold.
   domain: automation
   source_url: https://github.com/Cenvora/ha-veeam-br/blob/main/blueprints/automation/veeam_br/repository_space_low.yaml
   author: Cenvora
@@ -68,6 +71,16 @@ triggers:
     entity_id: !input repository_sensors
     below: !input threshold
     id: recovered
+
+conditions:
+  # Reloading the integration or restarting Home Assistant takes these sensors through
+  # unavailable, and a numeric_state trigger counts "unavailable -> 90" as a fresh crossing.
+  # Requiring a numeric previous state means only real crossings notify.
+  - condition: template
+    value_template: >-
+      {{ trigger.from_state is not none
+         and trigger.from_state.state | lower not in ['unknown', 'unavailable']
+         and trigger.from_state.state | float(-1) >= 0 }}
 
 variables:
   threshold: !input threshold

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -204,3 +204,30 @@ def test_hacs_declares_the_supported_home_assistant_version():
         "blueprints use the plural trigger/action keys, which need 2024.10+; the project "
         "targets 2026.1+"
     )
+
+
+def test_state_based_blueprints_survive_a_reload():
+    """A reload takes every entity through unavailable, which looks like a state change.
+
+    Without a guard, reloading the integration or restarting Home Assistant re-notifies about
+    conditions that were already true and already reported.
+    """
+    for name in ("job_failed.yaml", "repository_space_low.yaml"):
+        text = (BLUEPRINT_DIR / name).read_text(encoding="utf-8")
+        assert "trigger.from_state is not none" in text, f"{name} should ignore restored states"
+        assert "unavailable" in text, f"{name} should name the state it is guarding against"
+
+
+def test_numeric_blueprints_require_a_numeric_previous_state():
+    """numeric_state counts "unavailable -> 90" as crossing the threshold."""
+    text = (BLUEPRINT_DIR / "repository_space_low.yaml").read_text(encoding="utf-8")
+
+    assert "float(-1)" in text, "the previous state should have to be a real number"
+
+
+def test_state_triggers_that_pin_from_are_left_alone():
+    """ha_cluster_failover is already safe: "unavailable -> on" cannot match "off -> on"."""
+    text = (BLUEPRINT_DIR / "ha_cluster_failover.yaml").read_text(encoding="utf-8")
+
+    assert 'from: "off"' in text and 'to: "on"' in text
+    assert 'from: "on"' in text and 'to: "off"' in text


### PR DESCRIPTION
Reloading the integration, or restarting Home Assistant, takes every entity through unavailable. A numeric_state trigger counts "unavailable -> 90" as a fresh crossing, so every repository already over the threshold alerted again on every reload. The `for:` timer did not help — it only delayed the duplicate.

Requires the previous state to have been a real number, so only genuine crossings notify. The same applies to the recovery branch, which would otherwise announce a recovery that never happened.

job_failed already had this guard. ha_cluster_failover is safe by construction, because "unavailable -> on" does not match a trigger pinned to "off -> on" — now commented, since it looked like an omission next to the others.

Tests cover all three, so a future blueprint cannot quietly reintroduce it.