### PR TITLE
Let the user delete devices the server no longer reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,9 @@ attribute, so automations that need to match exactly have something stable:
 - **Veeam Community Edition / unlicensed servers**: Not supported. The integration detects
   this and raises a repair warning, but keeps running — see [Licensing](#licensing).
 - **API Version Compatibility**: Requires Veeam B&R 12.1 or newer
-- **Stale Devices**: Deleted jobs/repositories remain as devices until manual removal (planned enhancement)
+- **Stale Devices**: A job or repository deleted in Veeam is removed automatically on the next
+  poll. If the server reports none of a kind at all — which is indistinguishable from a failed
+  fetch — nothing is pruned automatically; use the device's **Delete** button instead.
 - **Large Deployments**: Polling 100+ jobs may take several seconds per cycle
 - **Real-time Updates**: Changes reflected every 60 seconds, not immediately
 - **SSL Certificates**: Self-signed certificates require SSL verification to be disabled

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -248,6 +248,72 @@ def _cluster_absent_reason(result) -> tuple[bool, str]:
     return False, detail or type(result).__name__
 
 
+# Device identifier prefixes, mapped to the coordinator data that keeps them alive
+DEVICE_KINDS = {
+    "job_": "jobs",
+    "repository_": "repositories",
+    "sobr_": "sobrs",
+}
+SINGLETON_KINDS = {
+    "server_": "server_info",
+    "license_": "license_info",
+    "ha_cluster_": "ha_cluster",
+}
+
+
+def device_is_current(identifiers, data: dict | None, entry_id: str) -> bool:
+    """Whether a device still corresponds to something the server reports.
+
+    Used to decide whether Home Assistant should let the user delete a device. A device that
+    is still being reported would simply reappear on the next poll, so refusing is kinder than
+    letting someone delete it twice.
+
+    An identifier this version does not recognise counts as stale: it cannot be something the
+    current code maintains.
+    """
+    if not data:
+        # Nothing to compare against — let the user clean up rather than blocking them
+        return False
+
+    for domain, identifier in identifiers:
+        if domain != DOMAIN:
+            continue
+
+        for prefix, key in DEVICE_KINDS.items():
+            if identifier.startswith(prefix):
+                wanted = identifier[len(prefix) :]
+                return any(item.get("id") == wanted for item in data.get(key) or [])
+
+        for prefix, key in SINGLETON_KINDS.items():
+            if identifier.startswith(prefix):
+                # These are one per config entry, so the suffix is the entry id
+                return identifier == f"{prefix}{entry_id}" and data.get(key) is not None
+
+    return False
+
+
+async def async_remove_config_entry_device(hass: HomeAssistant, entry: ConfigEntry, device) -> bool:
+    """Allow deleting a device from the UI once the server stops reporting it.
+
+    Without this, Home Assistant offers no Delete button at all and a job or repository that
+    no longer exists can only be disabled. Deletion is refused while the object is still
+    being reported, because the next poll would recreate it.
+    """
+    runtime = getattr(entry, "runtime_data", None) or {}
+    coordinator = runtime.get("coordinator")
+    data = getattr(coordinator, "data", None)
+
+    if device_is_current(device.identifiers, data, entry.entry_id):
+        _LOGGER.debug(
+            "Refusing to remove %s: the server still reports it, so it would come back",
+            device.name,
+        )
+        return False
+
+    _LOGGER.info("Removing device %s at the user's request", device.name)
+    return True
+
+
 def _license_issue_id(entry: ConfigEntry) -> str:
     """Repair issue ID for one config entry's license warning."""
     return f"unsupported_license_{entry.entry_id}"

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -282,6 +282,23 @@ async def async_setup_entry(
                     _LOGGER.info("Removing stale SOBR entity: %s", entity.entity_id)
                     entity_reg.async_remove(entity.entity_id)
 
+        # An empty collection is indistinguishable from a fetch that failed and degraded
+        # gracefully, so pruning on empty would delete every job device the first time the
+        # jobs endpoint errored. Deleting the last job of a kind is left to the per-device
+        # Delete button, which async_remove_config_entry_device now allows.
+        prunable = {
+            "job_": bool(current_jobs_in_data),
+            "repository_": bool(current_repos_in_data),
+            "sobr_": bool(current_sobrs_in_data),
+        }
+        for prefix, allowed in prunable.items():
+            if not allowed:
+                _LOGGER.debug(
+                    "Not pruning %s devices: nothing reported this cycle, which may be a "
+                    "failed fetch rather than a deletion",
+                    prefix.rstrip("_"),
+                )
+
         # Remove orphaned devices for jobs/repos/sobrs no longer present in API data.
         for device in list(dr.async_entries_for_config_entry(device_reg, entry_id)):
             for domain, identifier in device.identifiers:
@@ -289,19 +306,19 @@ async def async_setup_entry(
                     continue
                 if identifier.startswith("job_"):
                     job_id = identifier[len("job_") :]
-                    if job_id not in current_jobs_in_data:
+                    if job_id not in current_jobs_in_data and prunable["job_"]:
                         _LOGGER.info("Removing stale job device: %s", device.name)
                         device_reg.async_remove_device(device.id)
                         break
                 elif identifier.startswith("repository_"):
                     repo_id = identifier[len("repository_") :]
-                    if repo_id not in current_repos_in_data:
+                    if repo_id not in current_repos_in_data and prunable["repository_"]:
                         _LOGGER.info("Removing stale repository device: %s", device.name)
                         device_reg.async_remove_device(device.id)
                         break
                 elif identifier.startswith("sobr_"):
                     sobr_id = identifier[len("sobr_") :]
-                    if sobr_id not in current_sobrs_in_data:
+                    if sobr_id not in current_sobrs_in_data and prunable["sobr_"]:
                         _LOGGER.info("Removing stale SOBR device: %s", device.name)
                         device_reg.async_remove_device(device.id)
                         break

--- a/tests/test_device_removal.py
+++ b/tests/test_device_removal.py
@@ -1,0 +1,151 @@
+"""Tests for removing devices that no longer exist on the server.
+
+Two paths matter. Home Assistant only offers a per-device **Delete** button when an
+integration implements async_remove_config_entry_device, which is why a deleted repository
+could previously only be disabled. And the automatic sweep must not mistake a failed fetch for
+a deletion.
+
+device_is_current lives in __init__.py, which imports Home Assistant, so it is lifted out with
+ast — the same approach as the other coordinator helpers.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
+INIT_PATH = COMPONENT / "__init__.py"
+SENSOR_PATH = COMPONENT / "sensor.py"
+
+ENTRY_ID = "entry-1"
+
+
+@pytest.fixture(name="is_current", scope="module")
+def is_current_fixture():
+    """Execute device_is_current with the constants it depends on."""
+    tree = ast.parse(INIT_PATH.read_text(encoding="utf-8"))
+    wanted = [
+        node
+        for node in tree.body
+        if (isinstance(node, ast.FunctionDef) and node.name == "device_is_current")
+        or (
+            isinstance(node, ast.Assign)
+            and getattr(node.targets[0], "id", "") in {"DEVICE_KINDS", "SINGLETON_KINDS", "DOMAIN"}
+        )
+    ]
+    names = [
+        getattr(n, "name", getattr(getattr(n, "targets", [None])[0], "id", "")) for n in wanted
+    ]
+    assert "device_is_current" in names, f"helper not found, got {names}"
+
+    namespace = {"DOMAIN": "veeam_br"}
+    exec(compile(ast.Module(body=wanted, type_ignores=[]), str(INIT_PATH), "exec"), namespace)
+    return namespace["device_is_current"]
+
+
+def data(**overrides):
+    """Coordinator data with one of everything."""
+    payload = {
+        "jobs": [{"id": "job-1", "name": "Nightly"}],
+        "repositories": [{"id": "repo-1", "name": "Default"}],
+        "sobrs": [{"id": "sobr-1", "name": "Main"}],
+        "server_info": {"name": "vbr01"},
+        "license_info": {"status": "Valid"},
+        "ha_cluster": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def ids(identifier):
+    return {("veeam_br", identifier)}
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    ["job_job-1", "repository_repo-1", "sobr_sobr-1", f"server_{ENTRY_ID}", f"license_{ENTRY_ID}"],
+)
+def test_live_devices_may_not_be_deleted(is_current, identifier):
+    """Deleting one would just recreate it on the next poll."""
+    assert is_current(ids(identifier), data(), ENTRY_ID) is True
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    ["job_job-9", "repository_repo-9", "sobr_sobr-9"],
+)
+def test_deleted_objects_may_be_removed(is_current, identifier):
+    """The reported case: a repository deleted in Veeam should be purgeable in HA."""
+    assert is_current(ids(identifier), data(), ENTRY_ID) is False
+
+
+def test_a_cluster_device_becomes_removable_once_the_cluster_is_gone(is_current):
+    """ha_cluster is None on a server that is no longer clustered."""
+    assert is_current(ids(f"ha_cluster_{ENTRY_ID}"), data(), ENTRY_ID) is False
+    assert (
+        is_current(ids(f"ha_cluster_{ENTRY_ID}"), data(ha_cluster={"name": "VBR-HA"}), ENTRY_ID)
+        is True
+    )
+
+
+def test_a_singleton_from_another_entry_is_removable(is_current):
+    """A device left behind by a config entry that no longer exists."""
+    assert is_current(ids("server_some-old-entry"), data(), ENTRY_ID) is False
+
+
+def test_devices_from_other_integrations_are_not_claimed(is_current):
+    assert is_current({("hue", "light-1")}, data(), ENTRY_ID) is False
+
+
+def test_an_unrecognised_identifier_is_removable(is_current):
+    """It cannot be something this version maintains."""
+    assert is_current(ids("mystery_thing"), data(), ENTRY_ID) is False
+
+
+@pytest.mark.parametrize("empty", [None, {}])
+def test_without_data_the_user_is_not_blocked(is_current, empty):
+    """An unloaded or failed entry should not prevent cleaning up."""
+    assert is_current(ids("job_job-1"), empty, ENTRY_ID) is False
+
+
+def test_missing_collections_do_not_raise(is_current):
+    assert is_current(ids("job_job-1"), {"server_info": None}, ENTRY_ID) is False
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_the_delete_hook_exists_with_the_name_home_assistant_looks_for():
+    """The name is the contract: HA looks up this exact function on the integration."""
+    source = INIT_PATH.read_text(encoding="utf-8")
+
+    assert "async def async_remove_config_entry_device(" in source
+    hook = source[source.index("async def async_remove_config_entry_device") :]
+    hook = hook[: hook.index("\n\ndef ")] if "\n\ndef " in hook else hook
+
+    assert "device_is_current" in hook, "should refuse to delete a device that still exists"
+    assert "return False" in hook and "return True" in hook
+
+
+def test_the_automatic_sweep_will_not_purge_on_an_empty_fetch():
+    """An empty list is indistinguishable from a failed fetch that degraded gracefully.
+
+    Without this, the first time the jobs endpoint errored, every job device would be deleted.
+    """
+    source = SENSOR_PATH.read_text(encoding="utf-8")
+
+    assert "prunable" in source
+    for prefix in ("job_", "repository_", "sobr_"):
+        assert f'prunable["{prefix}"]' in source, f"{prefix} removal should be gated"
+
+
+def test_manual_deletion_covers_what_the_sweep_deliberately_skips():
+    """The sweep no longer prunes on empty, so the manual path has to work."""
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
+
+    assert "async def async_remove_config_entry_device" in init_source
+    assert "Delete button" in sensor_source or "async_remove_config_entry_device" in sensor_source


### PR DESCRIPTION
A job or repository deleted in Veeam could only be disabled in Home Assistant, never removed: HA offers a per-device Delete button only when an integration implements async_remove_config_entry_device, and this one did not.

It does now, and it refuses while the object is still being reported — deleting a live device would only recreate it on the next poll, which is a worse experience than being told no. A device belonging to an entry that no longer exists, or carrying an identifier this version does not recognise, is always removable.

Also fixes a hazard in the automatic sweep, which already removed devices missing from API data. It compared against the reported collection with no floor, so the first time the jobs endpoint failed and degraded gracefully to an empty list, every job device would have been deleted. Pruning now requires the server to have reported at least one object of that kind; deleting the last job or repository of a kind is left to the Delete button, which is exactly what it is for.