### PR TITLE
Keep "auto" as a stored value so it tracks the newest revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,16 @@ is that the caller chooses one. If the Swagger endpoints are unreachable or disa
 detection is skipped and the newest supported revision is used; select a revision manually if
 that is wrong for your server.
 
-The detected revision is **resolved once** and stored, when the entry is created or its
-options are changed. Upgrading VBR does not silently move an existing entry onto a newer
-revision — re-run **Configure** and choose *auto* again to pick up a newer one. Veeam also
-serves older revisions to newer servers, so a pinned lower revision stays a safe choice.
+*auto* is stored as a standing preference, not resolved away: it is re-evaluated on every
+startup and reload. Upgrading VBR, or updating `veeam-br` to a release that adds a newer
+revision, moves the entry onto the newer revision by itself — no reconfiguration needed. Pick a
+specific revision instead if you want it pinned.
+
+> [!NOTE]
+> A newer revision can rename enum values and add fields. That is the trade for automatic
+> upgrades: if a revision ever changes something this integration reads, *auto* will adopt it on
+> the next restart. Pin a version if you would rather adopt those changes deliberately. The
+> resolved revision is logged at startup and shown in the diagnostics download.
 
 | VBR Version | API Version | Notes |
 | ----------- | ----------- | ----- |

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -15,8 +15,10 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
+from .api_version import async_resolve_api_version
 from .const import (
     API_VERSIONS,
+    AUTO_API_VERSION,
     CONF_API_VERSION,
     CONF_VERIFY_SSL,
     DEFAULT_API_MODULE,
@@ -25,6 +27,7 @@ from .const import (
     DOMAIN,
     UPDATE_INTERVAL,
     check_api_feature_availability,
+    configured_api_version,
 )
 from .display import humanize
 from .licensing import describe_license, unsupported_license_reason
@@ -295,9 +298,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Veeam Backup & Replication from a config entry."""
     from veeam_br.client import VeeamClient
 
-    api_version = entry.options.get(
+    # "auto" is stored as the user's intent, not a version, so it is resolved on every setup
+    # — which means a restart picks up a server upgrade or a newer veeam-br automatically.
+    stored_version = entry.options.get(
         CONF_API_VERSION, entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
     )
+    if stored_version == AUTO_API_VERSION:
+        api_version = await async_resolve_api_version(
+            {**entry.data, CONF_API_VERSION: AUTO_API_VERSION}
+        )
+        _LOGGER.info(
+            "API version is set to auto; using %s for %s", api_version, entry.data[CONF_HOST]
+        )
+    else:
+        api_version = stored_version
+
     api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
     # Import UNSET type for proper type checking
@@ -911,6 +926,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.runtime_data = {
         "coordinator": coordinator,
         "veeam_client": veeam_client,
+        # Platforms and entities read the resolved version from here rather than re-reading
+        # the entry, which may only hold "auto"
+        "api_version": api_version,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/veeam_br/api_version.py
+++ b/custom_components/veeam_br/api_version.py
@@ -1,0 +1,68 @@
+"""Resolving which REST API version to talk to a server with.
+
+The API Version option can hold AUTO_API_VERSION, which is an intent rather than a version:
+"use the newest revision this server serves". It is stored as-is and resolved during setup, so
+a server upgrade — or a veeam-br release that adds a newer revision — is picked up on the next
+restart without anyone editing the entry.
+
+Shared by the config flow, which resolves it to validate the connection, and by setup, which
+resolves it for real on every start.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from .const import (
+    API_VERSIONS,
+    AUTO_API_VERSION,
+    CONF_API_VERSION,
+    CONF_VERIFY_SSL,
+    DEFAULT_API_VERSION,
+    DEFAULT_VERIFY_SSL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_resolve_api_version(data: dict[str, Any]) -> str:
+    """Resolve the configured API version, detecting it when set to auto.
+
+    Detection probes the server's Swagger documents (see veeam_br.discovery) and needs no
+    credentials, so it runs before the connection is validated. It is best-effort: a server
+    with Swagger disabled or gated reports nothing, and the static default is used instead
+    of failing setup.
+    """
+    api_version = data.get(CONF_API_VERSION, AUTO_API_VERSION)
+    if api_version != AUTO_API_VERSION:
+        return api_version
+
+    from veeam_br.discovery import detect_api_version
+
+    base_url = f"https://{data[CONF_HOST]}:{data[CONF_PORT]}"
+    verify_ssl = data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+
+    try:
+        detected = await detect_api_version(
+            base_url,
+            verify_ssl=verify_ssl,
+            versions=list(API_VERSIONS),
+        )
+    except Exception as err:  # noqa: BLE001 - detection must never fail the flow
+        _LOGGER.debug("API version detection failed: %s", err)
+        detected = None
+
+    if detected is None:
+        _LOGGER.info(
+            "Could not detect the API version of %s; using %s. Select a version manually "
+            "if this server needs a different one",
+            data[CONF_HOST],
+            DEFAULT_API_VERSION,
+        )
+        return DEFAULT_API_VERSION
+
+    _LOGGER.info("Detected API version %s on %s", detected, data[CONF_HOST])
+    return detected

--- a/custom_components/veeam_br/button.py
+++ b/custom_components/veeam_br/button.py
@@ -22,6 +22,7 @@ from .const import (
     DEFAULT_API_VERSION,
     DOMAIN,
     check_api_feature_availability,
+    configured_api_version,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,10 +42,7 @@ async def async_setup_entry(
 
     # Pre-import API endpoint modules to avoid blocking calls in event loop
     # Get the configured API version for proper module path
-    api_version = entry.options.get(
-        CONF_API_VERSION,
-        entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-    )
+    api_version = configured_api_version(entry)
     api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
     # Pre-import button API endpoints
@@ -81,10 +79,7 @@ async def async_setup_entry(
             return
 
         # Get the configured API version
-        api_version = entry.options.get(
-            CONF_API_VERSION,
-            entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-        )
+        api_version = configured_api_version(entry)
 
         new_entities = []
 
@@ -329,10 +324,7 @@ class VeeamRepositoryRescanButton(CoordinatorEntity, ButtonEntity):
         """
         try:
             # Get the API version
-            api_version = self._config_entry.options.get(
-                CONF_API_VERSION,
-                self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-            )
+            api_version = configured_api_version(self._config_entry)
             api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # VeeamClient handles token refresh automatically - no manual check needed
@@ -428,10 +420,7 @@ class VeeamSOBRExtentEnableSealedModeButton(VeeamSOBRExtentButtonBase):
         """Handle the button press to enable sealed mode for the extent."""
         try:
             # Get the API version
-            api_version = self._config_entry.options.get(
-                CONF_API_VERSION,
-                self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-            )
+            api_version = configured_api_version(self._config_entry)
             api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
@@ -503,10 +492,7 @@ class VeeamSOBRExtentDisableSealedModeButton(VeeamSOBRExtentButtonBase):
         """Handle the button press to disable sealed mode for the extent."""
         try:
             # Get the API version
-            api_version = self._config_entry.options.get(
-                CONF_API_VERSION,
-                self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-            )
+            api_version = configured_api_version(self._config_entry)
             api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
@@ -578,10 +564,7 @@ class VeeamSOBRExtentEnableMaintenanceModeButton(VeeamSOBRExtentButtonBase):
         """Handle the button press to enable maintenance mode for the extent."""
         try:
             # Get the API version
-            api_version = self._config_entry.options.get(
-                CONF_API_VERSION,
-                self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-            )
+            api_version = configured_api_version(self._config_entry)
             api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
@@ -654,10 +637,7 @@ class VeeamSOBRExtentDisableMaintenanceModeButton(VeeamSOBRExtentButtonBase):
         """Handle the button press to disable maintenance mode for the extent."""
         try:
             # Get the API version
-            api_version = self._config_entry.options.get(
-                CONF_API_VERSION,
-                self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-            )
+            api_version = configured_api_version(self._config_entry)
             api_module = API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
             # Import the body model for the request
@@ -740,10 +720,7 @@ class VeeamJobButtonBase(CoordinatorEntity, ButtonEntity):
 
     def _get_api_module(self) -> str:
         """Get the API module name based on the configured API version."""
-        api_version = self._config_entry.options.get(
-            CONF_API_VERSION,
-            self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-        )
+        api_version = configured_api_version(self._config_entry)
         return API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
     async def _import_spec_model(self, spec_name: str):
@@ -1029,10 +1006,7 @@ class VeeamHAClusterButtonBase(CoordinatorEntity, ButtonEntity):
 
     def _api_module(self) -> str:
         """Resolve the SDK package for the configured API version."""
-        api_version = self._config_entry.options.get(
-            CONF_API_VERSION,
-            self._config_entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-        )
+        api_version = configured_api_version(self._config_entry)
         return API_VERSIONS.get(api_version, DEFAULT_API_MODULE)
 
 

--- a/custom_components/veeam_br/config_flow.py
+++ b/custom_components/veeam_br/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv, selector
 import voluptuous as vol
 
+from .api_version import async_resolve_api_version
 from .const import (
     API_VERSIONS,
     AUTO_API_VERSION,
@@ -55,46 +56,6 @@ def _get_api_version_selector_config(
         return api_version_options, preferred_version
 
     return api_version_options, AUTO_API_VERSION
-
-
-async def async_resolve_api_version(data: dict[str, Any]) -> str:
-    """Resolve the configured API version, detecting it when set to auto.
-
-    Detection probes the server's Swagger documents (see veeam_br.discovery) and needs no
-    credentials, so it runs before the connection is validated. It is best-effort: a server
-    with Swagger disabled or gated reports nothing, and the static default is used instead
-    of failing setup.
-    """
-    api_version = data.get(CONF_API_VERSION, AUTO_API_VERSION)
-    if api_version != AUTO_API_VERSION:
-        return api_version
-
-    from veeam_br.discovery import detect_api_version
-
-    base_url = f"https://{data[CONF_HOST]}:{data[CONF_PORT]}"
-    verify_ssl = data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
-
-    try:
-        detected = await detect_api_version(
-            base_url,
-            verify_ssl=verify_ssl,
-            versions=list(API_VERSIONS),
-        )
-    except Exception as err:  # noqa: BLE001 - detection must never fail the flow
-        _LOGGER.debug("API version detection failed: %s", err)
-        detected = None
-
-    if detected is None:
-        _LOGGER.info(
-            "Could not detect the API version of %s; using %s. Select a version manually "
-            "if this server needs a different one",
-            data[CONF_HOST],
-            DEFAULT_API_VERSION,
-        )
-        return DEFAULT_API_VERSION
-
-    _LOGGER.info("Detected API version %s on %s", detected, data[CONF_HOST])
-    return detected
 
 
 async def async_find_working_port(data: dict[str, Any], configured_port: int) -> int | None:
@@ -160,12 +121,11 @@ def _load_veeam_br(api_version: str):
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
-    Mutates data[CONF_API_VERSION] when it is set to auto, so the caller stores the resolved
-    version rather than the sentinel: a server upgrade must not silently move an existing
-    entry onto a newer revision, where enum values are renamed and fields added.
+    A stored "auto" is resolved here only to test the connection — it is deliberately not
+    written back. Keeping the sentinel means every setup re-resolves it, so a server upgrade or
+    a newer veeam-br moves the entry onto the newer revision on its own.
     """
     api_version = await async_resolve_api_version(data)
-    data[CONF_API_VERSION] = api_version
 
     try:
         VeeamClient = await hass.async_add_executor_job(_load_veeam_br, api_version)
@@ -418,13 +378,9 @@ class VeeamBROptionsFlow(config_entries.OptionsFlow):
                 _LOGGER.exception("Unexpected exception validating options")
                 errors["base"] = "unknown"
             else:
-                # validate_input resolved auto into a concrete version; store that rather
-                # than the sentinel, so the entry keeps talking the same revision after a
-                # server upgrade
-                return self.async_create_entry(
-                    title="",
-                    data={**user_input, CONF_API_VERSION: test_data[CONF_API_VERSION]},
-                )
+                # Stored verbatim, including "auto": the point of auto is that it is
+                # re-resolved on every setup rather than frozen at the moment it was chosen
+                return self.async_create_entry(title="", data=user_input)
 
         api_version_options = [AUTO_API_VERSION, *API_VERSIONS.keys()]
 

--- a/custom_components/veeam_br/const.py
+++ b/custom_components/veeam_br/const.py
@@ -156,3 +156,26 @@ API_FEATURE_REQUIREMENTS = {
     "ha_cluster_switchover_button": "models.high_availability_switchover_spec",
     "ha_cluster_failover_button": "api.high_availability_ha_cluster",
 }
+
+
+def configured_api_version(entry) -> str:
+    """The API version to talk to this server with.
+
+    CONF_API_VERSION may hold AUTO_API_VERSION, which is a user intent rather than a version:
+    it means "use the newest revision this server serves", resolved during setup so a server
+    upgrade or a newer veeam-br is picked up on the next restart. The resolved value is kept in
+    entry.runtime_data, so platforms and entities read it from there rather than re-detecting.
+
+    Falls back to DEFAULT_API_VERSION when asked before setup has resolved anything, which is
+    the same answer detection would give if probing found nothing.
+    """
+    runtime = getattr(entry, "runtime_data", None)
+    if isinstance(runtime, dict):
+        resolved = runtime.get("api_version")
+        if resolved and resolved != AUTO_API_VERSION:
+            return resolved
+
+    stored = entry.options.get(
+        CONF_API_VERSION, entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
+    )
+    return DEFAULT_API_VERSION if stored == AUTO_API_VERSION else stored

--- a/custom_components/veeam_br/diagnostics.py
+++ b/custom_components/veeam_br/diagnostics.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_API_VERSION, DEFAULT_API_VERSION
+from .const import CONF_API_VERSION, DEFAULT_API_VERSION, configured_api_version
 from .licensing import unsupported_license_reason
 
 
@@ -40,10 +40,13 @@ async def async_get_config_entry_diagnostics(
             "domain": entry.domain,
             "title": entry.title,
             "unique_id": entry.unique_id,
-            # First questions in any bug report: which API revision, and which library
-            "api_version": entry.options.get(
+            # First questions in any bug report: which API revision, and which library.
+            # Both are reported because "auto" is a valid stored value, and knowing what it
+            # resolved to is the whole point.
+            "api_version_configured": entry.options.get(
                 CONF_API_VERSION, entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
             ),
+            "api_version": configured_api_version(entry),
             "veeam_br_version": _veeam_br_version(),
         },
         "coordinator": {

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -14,7 +14,13 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_API_VERSION, DEFAULT_API_VERSION, DOMAIN, check_api_feature_availability
+from .const import (
+    CONF_API_VERSION,
+    DEFAULT_API_VERSION,
+    DOMAIN,
+    check_api_feature_availability,
+    configured_api_version,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,10 +52,7 @@ async def async_setup_entry(
             return
 
         # Get the configured API version
-        api_version = entry.options.get(
-            CONF_API_VERSION,
-            entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION),
-        )
+        api_version = configured_api_version(entry)
 
         new_entities = []
 

--- a/tests/test_api_version_resolution.py
+++ b/tests/test_api_version_resolution.py
@@ -21,6 +21,8 @@ import pytest
 
 COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
 CONFIG_FLOW_PATH = COMPONENT / "config_flow.py"
+RESOLVER_PATH = COMPONENT / "api_version.py"
+INIT_PATH = COMPONENT / "__init__.py"
 CONST_PATH = COMPONENT / "const.py"
 
 AUTO = "auto"
@@ -35,7 +37,7 @@ DEFAULT = "1.3-rev2"
 
 def load_resolver(detected=None, raises=None, record=None):
     """Load async_resolve_api_version with veeam_br.discovery stubbed out."""
-    tree = ast.parse(CONFIG_FLOW_PATH.read_text(encoding="utf-8"))
+    tree = ast.parse(RESOLVER_PATH.read_text(encoding="utf-8"))
     func = next(
         node
         for node in tree.body
@@ -69,7 +71,7 @@ def load_resolver(detected=None, raises=None, record=None):
         "Any": object,
     }
     exec(
-        compile(ast.Module(body=[func], type_ignores=[]), str(CONFIG_FLOW_PATH), "exec"),
+        compile(ast.Module(body=[func], type_ignores=[]), str(RESOLVER_PATH), "exec"),
         namespace,
     )
     return namespace["async_resolve_api_version"]
@@ -150,19 +152,48 @@ def test_missing_api_version_is_treated_as_auto():
 # ---------------------------------------------------------------------------
 
 
-def test_sentinel_is_never_stored():
-    """The resolved version must reach the config entry, not the sentinel."""
-    content = CONFIG_FLOW_PATH.read_text(encoding="utf-8")
+def test_the_sentinel_is_stored_not_resolved_away():
+    """auto is a standing intent, so it has to survive being saved.
+
+    Resolving it at save time would freeze the entry on whichever revision was newest that
+    day, which defeats the point: a server upgrade or a newer veeam-br should move it on.
+    """
+    flow = CONFIG_FLOW_PATH.read_text(encoding="utf-8")
 
     assert (
-        "data[CONF_API_VERSION] = api_version" in content
-    ), "validate_input should write the resolved version back for the caller to store"
+        "data[CONF_API_VERSION] = api_version" not in flow
+    ), "validate_input must not write the resolved version back over the user's choice"
 
-    # The options flow builds its own dict to save, so it needs the resolved value too
-    options = content[content.index("class VeeamBROptionsFlow") :]
+    options = flow[flow.index("class VeeamBROptionsFlow") :]
     assert (
-        "CONF_API_VERSION: test_data[CONF_API_VERSION]" in options
-    ), "the options flow must persist the resolved version, not the submitted sentinel"
+        'async_create_entry(title="", data=user_input)' in options
+    ), "the options flow should store what was chosen, including auto"
+
+
+def test_setup_resolves_the_sentinel_on_every_start():
+    """That is what makes a stored auto keep up with the server and the library."""
+    init = INIT_PATH.read_text(encoding="utf-8")
+
+    assert "stored_version == AUTO_API_VERSION" in init
+    assert "await async_resolve_api_version(" in init
+
+    # The answer has to reach the platforms, which cannot re-detect for themselves
+    assert '"api_version": api_version' in init
+
+
+def test_readers_go_through_one_resolver():
+    """A reader seeing the raw "auto" would fall back to the default and silently disagree
+    with the version the coordinator is actually using."""
+    direct_read = "entry.options.get("
+
+    for name in ("button.py", "sensor.py", "diagnostics.py"):
+        source = (COMPONENT / name).read_text(encoding="utf-8")
+        assert "configured_api_version" in source, f"{name} should use the shared resolver"
+
+    # diagnostics reads the stored value on purpose, to report it alongside the resolved one
+    for name in ("button.py", "sensor.py"):
+        source = (COMPONENT / name).read_text(encoding="utf-8")
+        assert direct_read not in source, f"{name} still reads the stored value directly"
 
 
 def test_auto_is_offered_and_is_the_default():
@@ -195,3 +226,69 @@ def test_auto_option_is_explained_in_strings():
         data = json.loads((COMPONENT / name).read_text(encoding="utf-8"))
         description = data["config"]["step"]["user"]["data_description"]["api_version"]
         assert "auto" in description.lower()
+
+
+# ---------------------------------------------------------------------------
+# The shared resolver, which every reader depends on
+# ---------------------------------------------------------------------------
+
+
+def _load_const():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("veeam_br_const", CONST_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Entry:
+    """Duck-typed config entry."""
+
+    def __init__(self, data=None, options=None, runtime_data=None):
+        self.data = data or {}
+        self.options = options or {}
+        if runtime_data is not None:
+            self.runtime_data = runtime_data
+
+
+def test_the_resolved_version_wins_once_setup_has_run():
+    const = _load_const()
+    entry = Entry(data={"api_version": "auto"}, runtime_data={"api_version": "1.2-rev1"})
+
+    assert const.configured_api_version(entry) == "1.2-rev1"
+
+
+def test_auto_before_setup_falls_back_to_the_default():
+    """Platforms can ask before the coordinator exists; the default is the honest answer."""
+    const = _load_const()
+
+    assert const.configured_api_version(Entry(data={"api_version": "auto"})) == DEFAULT
+
+
+def test_a_pinned_version_is_returned_as_is():
+    const = _load_const()
+
+    assert const.configured_api_version(Entry(data={"api_version": "1.3-rev0"})) == "1.3-rev0"
+
+
+def test_options_override_data():
+    const = _load_const()
+    entry = Entry(data={"api_version": "1.2-rev1"}, options={"api_version": "1.3-rev1"})
+
+    assert const.configured_api_version(entry) == "1.3-rev1"
+
+
+def test_a_stale_auto_in_runtime_data_is_ignored():
+    """Belt and braces: runtime_data should never hold the sentinel, and if it did, returning
+    it would break every API_VERSIONS lookup downstream."""
+    const = _load_const()
+    entry = Entry(data={"api_version": "auto"}, runtime_data={"api_version": "auto"})
+
+    assert const.configured_api_version(entry) == DEFAULT
+
+
+def test_an_entry_with_no_version_at_all_still_works():
+    const = _load_const()
+
+    assert const.configured_api_version(Entry()) == DEFAULT


### PR DESCRIPTION
auto was resolved to a concrete version the moment an entry was created, which froze it on whichever revision was newest that day. Upgrading VBR, or updating veeam-br to a release that ships a newer revision, then had no effect until someone reconfigured the entry by hand.

It is now stored as-is and resolved on every setup, so a restart or reload picks up the newer revision on its own.

That means the stored value can be a sentinel rather than a version, and roughly a dozen places read it — every button, the sensor platform, diagnostics — each of which would otherwise see "auto", fall back to the default module, and silently disagree with the version the coordinator was actually using. They all go through one configured_api_version(entry) helper now, which prefers the resolved value that setup publishes in runtime_data.

The resolver moved out of config_flow into api_version.py, since setup needs it too and importing the config flow from __init__ to get at it would be backwards.

Diagnostics reports both the configured value and what it resolved to, because "auto" on its own answers nothing in a bug report.

The trade is stated in the README: a newer revision can rename enum values and add fields, and auto will adopt it on the next restart. Pinning a version remains the way to adopt those deliberately.