### PR TITLE
Add backup proxies and WAN accelerators

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ The integration also creates devices for:
 - **License**: License device has sensors for status, edition, expiration dates, and — on
   instance-based licences — instances licensed, instances used and percentage used, with the
   per-workload-type breakdown as attributes.
+- **Backup Proxies**: each proxy device has online, enabled and out-of-date sensors, a type
+  sensor carrying its host as an attribute, and enable/disable buttons for taking a proxy out
+  of service during maintenance.
+- **WAN Accelerators**: cache size, with the cache folder, traffic port, stream count and
+  high-bandwidth mode as attributes.
 - **High Availability Cluster**: on a clustered Veeam B&R 13.1 server (API `1.3-rev2`), a
   cluster device with online and failover-in-progress sensors, cluster endpoint and last-online
   diagnostics, per-node replication state, Patroni role and replication lag, plus switchover
@@ -291,6 +296,14 @@ One digest a day: how many jobs succeeded, warned or failed, and which need atte
 [![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FCenvora%2Fha-veeam-br%2Fmain%2Fblueprints%2Fautomation%2Fveeam_br%2Fdaily_backup_summary.yaml)
 
 <sub>Source: [`daily_backup_summary.yaml`](blueprints/automation/veeam_br/daily_backup_summary.yaml)</sub>
+
+### Backup proxy offline
+
+Fires when a proxy stays offline, and optionally when it returns. Can ignore proxies you have deliberately disabled.
+
+[![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FCenvora%2Fha-veeam-br%2Fmain%2Fblueprints%2Fautomation%2Fveeam_br%2Fproxy_offline.yaml)
+
+<sub>Source: [`proxy_offline.yaml`](blueprints/automation/veeam_br/proxy_offline.yaml)</sub>
 
 ### A note on which sensor to pick
 
@@ -482,6 +495,8 @@ The integration monitors the following Veeam objects:
 - ✅ **Scale-Out Repositories** - SOBR and extents
 - ✅ **Server Information** - Veeam server details
 - ✅ **License Information** - License status and expiration
+- ✅ **Backup Proxies** - online state, enabled state, out-of-date components, enable/disable
+- ✅ **WAN Accelerators** - cache configuration
 - ✅ **High Availability Cluster** - cluster state, node roles and replication lag, with
   switchover and failover actions (Veeam B&R 13.1 and the `1.3-rev2` API version)
 

--- a/blueprints/automation/veeam_br/proxy_offline.yaml
+++ b/blueprints/automation/veeam_br/proxy_offline.yaml
@@ -1,0 +1,111 @@
+blueprint:
+  name: Veeam backup proxy offline
+  description: >-
+    Notify when a Veeam backup proxy goes offline, and again when it comes back.
+
+    A proxy that is offline does not fail jobs immediately — Veeam reassigns work to whatever
+    proxies remain — so this often goes unnoticed until backups start taking noticeably longer
+    or a job has nowhere to run.
+
+    Pick the **Online** sensors of the proxies to watch. A proxy that is deliberately disabled
+    reports offline too, so the blueprint can skip proxies you have disabled on purpose.
+  domain: automation
+  source_url: https://github.com/Cenvora/ha-veeam-br/blob/main/blueprints/automation/veeam_br/proxy_offline.yaml
+  author: Cenvora
+  input:
+    proxy_online_sensors:
+      name: Proxy Online sensors
+      description: One or more Veeam proxy "Online" sensors.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - integration: veeam_br
+              domain: binary_sensor
+    offline_for:
+      name: Offline for
+      description: >-
+        How long the proxy must stay offline before notifying, so a restart of the proxy host
+        does not raise an alert.
+      default:
+        minutes: 5
+      selector:
+        duration:
+    ignore_disabled:
+      name: Ignore proxies you have disabled
+      description: >-
+        A disabled proxy is offline by design. Requires the proxy's **Enabled** sensor to exist
+        (it does by default).
+      default: true
+      selector:
+        boolean:
+    notification_action:
+      name: Notification action
+      description: >-
+        What to run when a proxy goes offline. Available variables: `proxy_name`,
+        `proxy_entity_id`, and ready-made `title` and `message`.
+      selector:
+        action:
+    recovery_action:
+      name: Recovery action
+      description: Optional. What to run when the proxy comes back online.
+      default: []
+      selector:
+        action:
+
+mode: queued
+max: 20
+
+triggers:
+  - trigger: state
+    entity_id: !input proxy_online_sensors
+    from: "on"
+    to: "off"
+    for: !input offline_for
+    id: offline
+  - trigger: state
+    entity_id: !input proxy_online_sensors
+    from: "off"
+    to: "on"
+    id: online
+
+variables:
+  ignore_disabled: !input ignore_disabled
+  proxy_entity_id: "{{ trigger.entity_id }}"
+  # Each proxy is its own device, so the device name is the proxy name
+  proxy_name: >-
+    {{ device_attr(trigger.entity_id, 'name_by_user')
+       or device_attr(trigger.entity_id, 'name')
+       or trigger.to_state.name | replace(' Online', '') }}
+  # The Enabled sensor lives on the same device, so it can be found by walking its entities
+  enabled_entity: >-
+    {{ device_entities(device_id(trigger.entity_id))
+       | select('search', '_enabled$') | list | first | default('') }}
+  proxy_disabled: >-
+    {{ enabled_entity != '' and states(enabled_entity) == 'off' }}
+  title: >-
+    {{ 'Veeam proxy offline: ' ~ proxy_name
+       if trigger.id == 'offline'
+       else 'Veeam proxy back online: ' ~ proxy_name }}
+  message: >-
+    {{ 'Backup proxy ' ~ proxy_name ~ ' has been offline for a while. Jobs will run on the '
+       ~ 'remaining proxies, which may make them slower.'
+       if trigger.id == 'offline'
+       else 'Backup proxy ' ~ proxy_name ~ ' is online again.' }}
+
+conditions:
+  # A reload takes every entity through unavailable, and both triggers pin from/to, so a
+  # restart cannot re-alert. This guards the disabled-on-purpose case instead.
+  - condition: template
+    value_template: "{{ not (ignore_disabled and proxy_disabled) }}"
+
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: offline
+        sequence: !input notification_action
+      - conditions:
+          - condition: trigger
+            id: online
+        sequence: !input recovery_action

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -256,6 +256,8 @@ DEVICE_KINDS = {
     "job_": "jobs",
     "repository_": "repositories",
     "sobr_": "sobrs",
+    "proxy_": "proxies",
+    "wan_": "wan_accelerators",
 }
 SINGLETON_KINDS = {
     "server_": "server_info",
@@ -454,6 +456,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "repositories.get_all_repositories",
         "repositories.get_all_repositories_states",
         "repositories.get_all_scale_out_repositories",
+        "proxies.get_all_proxies_states",
+        "wan_accelerators.get_all_wan_accelerators",
     ]
     if ha_cluster_supported:
         api_endpoints.append("high_availability_ha_cluster.get_high_availability_cluster")
@@ -918,6 +922,132 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             _LOGGER.debug("Total SOBRs added to coordinator data: %d", len(sobr_list))
 
+            # Fetch backup proxies. The states endpoint carries the configuration this needs
+            # as well as online/disabled/out-of-date, so one call covers both.
+            proxies_list = []
+            try:
+                proxies_api = await asyncio.to_thread(veeam_client.api, "proxies")
+                proxies_result = await veeam_client.call(proxies_api.get_all_proxies_states)
+
+                for proxy in getattr(proxies_result, "data", None) or []:
+                    try:
+                        proxy_id = get_uuid_value(proxy.id)
+                        if not proxy_id:
+                            _LOGGER.warning(
+                                "Skipping proxy %s: no usable ID",
+                                getattr(proxy, "name", "Unknown"),
+                            )
+                            continue
+
+                        proxies_list.append(
+                            {
+                                "id": proxy_id,
+                                "name": proxy.name or "Unknown",
+                                "description": getattr(proxy, "description", "") or "",
+                                "type": humanize(get_enum_value(proxy.type_), "Unknown"),
+                                "type_raw": get_enum_value(proxy.type_),
+                                "host_id": get_uuid_value(getattr(proxy, "host_id", None)),
+                                "host_name": getattr(proxy, "host_name", None) or None,
+                                "is_online": _bool_or_none(proxy, "is_online"),
+                                "is_disabled": _bool_or_none(proxy, "is_disabled"),
+                                "is_out_of_date": _bool_or_none(proxy, "is_out_of_date"),
+                            }
+                        )
+                    except (ValueError, KeyError, AttributeError, TypeError) as err:
+                        _LOGGER.warning(
+                            "Failed to parse proxy %s: %s",
+                            getattr(proxy, "name", "Unknown"),
+                            err,
+                        )
+                        continue
+            except (AttributeError, KeyError, TypeError, ValueError) as err:
+                _LOGGER.warning("Failed to parse proxies: %s", err)
+            except Exception as err:
+                _LOGGER.warning("Failed to fetch proxies: %s", err)
+
+            _LOGGER.debug("Total proxies added to coordinator data: %d", len(proxies_list))
+
+            # Fetch WAN accelerators. There is no states endpoint for these, so this is
+            # configuration only: cache location and size, and the traffic settings.
+            wan_accelerators_list = []
+            try:
+                wan_api = await asyncio.to_thread(veeam_client.api, "wan_accelerators")
+                wan_result = await veeam_client.call(wan_api.get_all_wan_accelerators)
+
+                for accelerator in getattr(wan_result, "data", None) or []:
+                    try:
+                        wan_id = get_uuid_value(getattr(accelerator, "id", None))
+                        if not wan_id:
+                            _LOGGER.warning(
+                                "Skipping WAN accelerator %s: no usable ID",
+                                getattr(accelerator, "name", "Unknown"),
+                            )
+                            continue
+
+                        server = getattr(accelerator, "server", None)
+                        cache = getattr(accelerator, "cache", None)
+                        has_server = not _is_unset(server)
+                        has_cache = not _is_unset(cache)
+
+                        wan_accelerators_list.append(
+                            {
+                                "id": wan_id,
+                                "name": getattr(accelerator, "name", None) or "Unknown",
+                                "host_id": (
+                                    get_uuid_value(getattr(server, "host_id", None))
+                                    if has_server
+                                    else None
+                                ),
+                                "description": (
+                                    _license_text(server, "description", default="")
+                                    if has_server
+                                    else ""
+                                ),
+                                "traffic_port": (
+                                    _number_or_none(server, "traffic_port") if has_server else None
+                                ),
+                                "streams_count": (
+                                    _number_or_none(server, "streams_count") if has_server else None
+                                ),
+                                "high_bandwidth_mode": (
+                                    _bool_or_none(server, "high_bandwidth_mode_enabled")
+                                    if has_server
+                                    else None
+                                ),
+                                "cache_folder": (
+                                    _license_text(cache, "cache_folder", default=None)
+                                    if has_cache
+                                    else None
+                                ),
+                                "cache_size": (
+                                    _number_or_none(cache, "cache_size") if has_cache else None
+                                ),
+                                "cache_size_unit": (
+                                    get_enum_value(
+                                        getattr(cache, "cache_size_unit", None), "Unknown"
+                                    )
+                                    if has_cache
+                                    else None
+                                ),
+                            }
+                        )
+                    except (ValueError, KeyError, AttributeError, TypeError) as err:
+                        _LOGGER.warning(
+                            "Failed to parse WAN accelerator %s: %s",
+                            getattr(accelerator, "name", "Unknown"),
+                            err,
+                        )
+                        continue
+            except (AttributeError, KeyError, TypeError, ValueError) as err:
+                _LOGGER.warning("Failed to parse WAN accelerators: %s", err)
+            except Exception as err:
+                _LOGGER.warning("Failed to fetch WAN accelerators: %s", err)
+
+            _LOGGER.debug(
+                "Total WAN accelerators added to coordinator data: %d",
+                len(wan_accelerators_list),
+            )
+
             # Fetch High Availability cluster configuration and state. Only reachable on
             # 1.3-rev2 and newer, and only answered by a server that is actually clustered —
             # an unclustered server is the common case, not an error.
@@ -963,6 +1093,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "license_info": license_info,
                 "repositories": repositories_list,
                 "sobrs": sobr_list,
+                "proxies": proxies_list,
+                "wan_accelerators": wan_accelerators_list,
                 "ha_cluster": ha_cluster,
                 "diagnostics": {
                     "connected": connected,

--- a/custom_components/veeam_br/button.py
+++ b/custom_components/veeam_br/button.py
@@ -69,6 +69,7 @@ async def async_setup_entry(
     added_repository_ids: set[str] = set()
     added_sobr_extent_ids: set[tuple[str, str]] = set()  # (sobr_id, extent_id) tuples
     added_job_ids: set[str] = set()
+    added_proxy_ids: set[str] = set()
     ha_cluster_added = False
 
     @callback
@@ -173,6 +174,22 @@ async def async_setup_entry(
                         sobr_id,
                         extent_id,
                     )
+
+        # ---- PROXY BUTTONS - a proxy can be taken out of service without deleting it ----
+        if check_api_feature_availability(api_version, "api.proxies"):
+            for proxy in coordinator.data.get("proxies", []):
+                proxy_id = proxy.get("id")
+                if not proxy_id or proxy_id in added_proxy_ids:
+                    continue
+
+                new_entities.extend(
+                    [
+                        VeeamProxyEnableButton(coordinator, entry, proxy, veeam_client),
+                        VeeamProxyDisableButton(coordinator, entry, proxy, veeam_client),
+                    ]
+                )
+                added_proxy_ids.add(proxy_id)
+                _LOGGER.debug("Adding proxy buttons for: %s", proxy.get("name"))
 
         # ---- HA CLUSTER BUTTONS (once) - clustered servers on 1.3-rev2 and newer ----
         if (
@@ -1091,3 +1108,93 @@ class VeeamHAClusterFailoverButton(VeeamHAClusterButtonBase):
         except Exception as err:
             _LOGGER.error("Failed to fail over the HA cluster: %s", err)
             raise
+
+
+# ===========================
+# PROXY BUTTONS
+#
+# Disabling a proxy takes it out of service without deleting it, which is what an operator
+# reaches for during maintenance on the proxy host.
+# ===========================
+
+
+class VeeamProxyButtonBase(CoordinatorEntity, ButtonEntity):
+    """Base class for proxy buttons."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator, config_entry, proxy_data, veeam_client):
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._veeam_client = veeam_client
+        self._proxy_id = proxy_data.get("id")
+        self._proxy_name = proxy_data.get("name", "Unknown")
+
+    def _proxy(self) -> dict | None:
+        if not self.coordinator.data:
+            return None
+        for proxy in self.coordinator.data.get("proxies", []):
+            if proxy.get("id") == self._proxy_id:
+                return proxy
+        return None
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._proxy() is not None
+
+    @property
+    def device_info(self):
+        """Return device info for this proxy."""
+        return {
+            "identifiers": {(DOMAIN, f"proxy_{self._proxy_id}")},
+            "name": self._proxy_name,
+            "manufacturer": "Veeam",
+            "model": "Backup Proxy",
+        }
+
+    async def _call(self, operation_name: str, action: str) -> None:
+        """Run one proxy operation and refresh."""
+        try:
+            proxies_api = await asyncio.to_thread(self._veeam_client.api, "proxies")
+            await self._veeam_client.call(getattr(proxies_api, operation_name), id=self._proxy_id)
+            _LOGGER.info("%s proxy %s", action, self._proxy_name)
+            await self.coordinator.async_request_refresh()
+        except Exception as err:
+            _LOGGER.error("Failed to %s proxy %s: %s", action.lower(), self._proxy_name, err)
+            raise
+
+
+class VeeamProxyEnableButton(VeeamProxyButtonBase):
+    """Button to put a proxy back into service."""
+
+    def __init__(self, coordinator, config_entry, proxy_data, veeam_client):
+        super().__init__(coordinator, config_entry, proxy_data, veeam_client)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_enable"
+        self._attr_name = "Enable"
+
+    @property
+    def icon(self) -> str:
+        return "mdi:play"
+
+    async def async_press(self) -> None:
+        """Handle the button press to enable the proxy."""
+        await self._call("enable_proxy", "Enabled")
+
+
+class VeeamProxyDisableButton(VeeamProxyButtonBase):
+    """Button to take a proxy out of service."""
+
+    def __init__(self, coordinator, config_entry, proxy_data, veeam_client):
+        super().__init__(coordinator, config_entry, proxy_data, veeam_client)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_disable"
+        self._attr_name = "Disable"
+
+    @property
+    def icon(self) -> str:
+        return "mdi:pause"
+
+    async def async_press(self) -> None:
+        """Handle the button press to disable the proxy."""
+        await self._call("disable_proxy", "Disabled")

--- a/custom_components/veeam_br/const.py
+++ b/custom_components/veeam_br/const.py
@@ -151,6 +151,10 @@ API_FEATURE_REQUIREMENTS = {
     "sobr_data": "api.repositories",  # SOBRs use repositories API
     "license_data": "api.license_",
     "server_data": "api.service",
+    "proxy_data": "api.proxies",
+    "proxy_enable_button": "api.proxies",
+    "proxy_disable_button": "api.proxies",
+    "wan_accelerator_data": "api.wan_accelerators",
     # High Availability cluster: API 1.3-rev2 (VBR 13.1) and newer only
     "ha_cluster_data": "api.high_availability_ha_cluster",
     "ha_cluster_switchover_button": "models.high_availability_switchover_spec",

--- a/custom_components/veeam_br/display.py
+++ b/custom_components/veeam_br/display.py
@@ -84,6 +84,12 @@ OVERRIDES = {
     "scaleout": "Scale-out",
     "cifs": "SMB share",
     "nfs": "NFS share",
+    # Proxy types (EProxyType)
+    "generalpurposeproxy": "General purpose",
+    "viproxy": "VMware",
+    "hvproxy": "Hyper-V",
+    "nutanixahv": "Nutanix AHV",
+    "pve": "Proxmox VE",
     # Patroni node roles and states, from the HA cluster
     "standbyleader": "Standby leader",
     "syncstandby": "Sync standby",

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -38,6 +38,8 @@ async def async_setup_entry(
     added_job_ids: set[str] = set()
     added_repository_ids: set[str] = set()
     added_sobr_ids: set[str] = set()
+    added_proxy_ids: set[str] = set()
+    added_wan_ids: set[str] = set()
     server_added = False
     license_added = False
     ha_cluster_added = False
@@ -135,6 +137,35 @@ async def async_setup_entry(
                     sobr.get("name"),
                     sobr_id,
                 )
+
+        # ---- PROXY SENSORS (dynamic) - one device per backup proxy ----
+        if check_api_feature_availability(api_version, "api.proxies"):
+            for proxy in coordinator.data.get("proxies", []):
+                proxy_id = proxy.get("id")
+                if not proxy_id or proxy_id in added_proxy_ids:
+                    continue
+
+                new_entities.extend(
+                    [
+                        VeeamProxyOnlineSensor(coordinator, entry, proxy),
+                        VeeamProxyEnabledSensor(coordinator, entry, proxy),
+                        VeeamProxyOutOfDateSensor(coordinator, entry, proxy),
+                        VeeamProxyTypeSensor(coordinator, entry, proxy),
+                    ]
+                )
+                added_proxy_ids.add(proxy_id)
+                _LOGGER.debug("Adding proxy sensors for: %s", proxy.get("name"))
+
+        # ---- WAN ACCELERATOR SENSORS (dynamic) - one device per accelerator ----
+        if check_api_feature_availability(api_version, "api.wan_accelerators"):
+            for accelerator in coordinator.data.get("wan_accelerators", []):
+                wan_id = accelerator.get("id")
+                if not wan_id or wan_id in added_wan_ids:
+                    continue
+
+                new_entities.append(VeeamWanAcceleratorCacheSensor(coordinator, entry, accelerator))
+                added_wan_ids.add(wan_id)
+                _LOGGER.debug("Adding WAN accelerator sensors for: %s", accelerator.get("name"))
 
         # ---- SERVER SENSORS (once) - Server info becomes a device with multiple sensors ----
         # Server data comes from service API, only create if available
@@ -1874,3 +1905,231 @@ class VeeamLicenseInstancesUsedPercentSensor(VeeamLicenseBaseSensor):
         if value >= 70:
             return "mdi:gauge-low"
         return "mdi:gauge"
+
+
+# ===========================
+# BACKUP PROXIES (device per proxy)
+#
+# get_all_proxies_states carries both the configuration and the live state, so one call feeds
+# every entity here.
+# ===========================
+
+
+class VeeamProxyMixin:
+    """Mixin providing shared proxy functionality."""
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        """Initialize the mixin."""
+        self._config_entry = config_entry
+        self._proxy_id = proxy_data.get("id")
+        self._proxy_name = proxy_data.get("name", "Unknown")
+
+    def _proxy(self) -> dict[str, Any] | None:
+        """Get this proxy from coordinator data."""
+        if not self.coordinator.data:
+            return None
+        for proxy in self.coordinator.data.get("proxies", []):
+            if proxy.get("id") == self._proxy_id:
+                return proxy
+        return None
+
+    @property
+    def available(self) -> bool:
+        """A proxy removed from the server should not keep reporting."""
+        return super().available and self._proxy() is not None
+
+    @property
+    def device_info(self):
+        """Return device info for this proxy."""
+        return {
+            "identifiers": {(DOMAIN, f"proxy_{self._proxy_id}")},
+            "name": self._proxy_name,
+            "manufacturer": "Veeam",
+            "model": "Backup Proxy",
+        }
+
+
+class VeeamProxyBaseSensor(VeeamProxyMixin, CoordinatorEntity, SensorEntity):
+    """Base class for proxy sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamProxyMixin.__init__(self, coordinator, config_entry, proxy_data)
+
+
+class VeeamProxyBinarySensorBase(VeeamProxyMixin, CoordinatorEntity, BinarySensorEntity):
+    """Base class for proxy binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamProxyMixin.__init__(self, coordinator, config_entry, proxy_data)
+
+
+class VeeamProxyOnlineSensor(VeeamProxyBinarySensorBase):
+    """Binary sensor for whether a proxy is online."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        super().__init__(coordinator, config_entry, proxy_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_online"
+        self._attr_name = "Online"
+
+    @property
+    def is_on(self) -> bool | None:
+        proxy = self._proxy()
+        return proxy.get("is_online") if proxy else None
+
+
+class VeeamProxyEnabledSensor(VeeamProxyBinarySensorBase):
+    """Binary sensor for whether a proxy is enabled.
+
+    Reported as enabled rather than disabled, so "on" is the healthy state and the tile colour
+    matches every other sensor here.
+    """
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        super().__init__(coordinator, config_entry, proxy_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_enabled"
+        self._attr_name = "Enabled"
+
+    @property
+    def is_on(self) -> bool | None:
+        proxy = self._proxy()
+        if not proxy or proxy.get("is_disabled") is None:
+            return None
+        return not proxy["is_disabled"]
+
+    @property
+    def icon(self) -> str:
+        return "mdi:play-circle" if self.is_on else "mdi:pause-circle"
+
+
+class VeeamProxyOutOfDateSensor(VeeamProxyBinarySensorBase):
+    """Binary sensor for a proxy running outdated components."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        super().__init__(coordinator, config_entry, proxy_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_out_of_date"
+        self._attr_name = "Out Of Date"
+
+    @property
+    def is_on(self) -> bool | None:
+        proxy = self._proxy()
+        return proxy.get("is_out_of_date") if proxy else None
+
+
+class VeeamProxyTypeSensor(VeeamProxyBaseSensor):
+    """Sensor for the proxy type."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        super().__init__(coordinator, config_entry, proxy_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_type"
+        self._attr_name = "Type"
+
+    @property
+    def native_value(self) -> str | None:
+        proxy = self._proxy()
+        return proxy.get("type") if proxy else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        proxy = self._proxy() or {}
+        return {
+            "raw_value": proxy.get("type_raw"),
+            "host": proxy.get("host_name"),
+            "description": proxy.get("description"),
+        }
+
+    @property
+    def icon(self) -> str:
+        return "mdi:transit-connection-variant"
+
+
+# ===========================
+# WAN ACCELERATORS (device per accelerator)
+#
+# There is no states endpoint for these, so this is configuration only.
+# ===========================
+
+
+class VeeamWanAcceleratorMixin:
+    """Mixin providing shared WAN accelerator functionality."""
+
+    def __init__(self, coordinator, config_entry, accelerator_data):
+        """Initialize the mixin."""
+        self._config_entry = config_entry
+        self._wan_id = accelerator_data.get("id")
+        self._wan_name = accelerator_data.get("name", "Unknown")
+
+    def _accelerator(self) -> dict[str, Any] | None:
+        if not self.coordinator.data:
+            return None
+        for accelerator in self.coordinator.data.get("wan_accelerators", []):
+            if accelerator.get("id") == self._wan_id:
+                return accelerator
+        return None
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._accelerator() is not None
+
+    @property
+    def device_info(self):
+        """Return device info for this WAN accelerator."""
+        return {
+            "identifiers": {(DOMAIN, f"wan_{self._wan_id}")},
+            "name": self._wan_name,
+            "manufacturer": "Veeam",
+            "model": "WAN Accelerator",
+        }
+
+
+class VeeamWanAcceleratorCacheSensor(VeeamWanAcceleratorMixin, CoordinatorEntity, SensorEntity):
+    """Sensor for the configured cache size."""
+
+    _attr_has_entity_name = True
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, config_entry, accelerator_data):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamWanAcceleratorMixin.__init__(self, coordinator, config_entry, accelerator_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_wan_{self._wan_id}_cache_size"
+        self._attr_name = "Cache Size"
+
+    @property
+    def native_value(self):
+        accelerator = self._accelerator()
+        return accelerator.get("cache_size") if accelerator else None
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Veeam reports the unit alongside the number rather than fixing it."""
+        accelerator = self._accelerator() or {}
+        unit = accelerator.get("cache_size_unit")
+        # Home Assistant expects the symbol, and Veeam spells it out
+        return {"TB": "TB", "GB": "GB", "MB": "MB"}.get(unit, unit)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        accelerator = self._accelerator() or {}
+        return {
+            "cache_folder": accelerator.get("cache_folder"),
+            "traffic_port": accelerator.get("traffic_port"),
+            "streams": accelerator.get("streams_count"),
+            "high_bandwidth_mode": accelerator.get("high_bandwidth_mode"),
+            "description": accelerator.get("description"),
+        }
+
+    @property
+    def icon(self) -> str:
+        return "mdi:database-clock"

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -161,6 +161,7 @@ def test_optional_inputs_have_defaults(path):
         "repository_sensors",
         "expiry_sensors",
         "failover_sensor",
+        "proxy_online_sensors",
         "notification_action",
     }
     assert set(mandatory) <= allowed, f"unexpectedly mandatory: {sorted(set(mandatory) - allowed)}"

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -1,0 +1,195 @@
+"""Tests for backup proxy and WAN accelerator support.
+
+Proxy figures come from get_all_proxies_states, which carries both the configuration and the
+live state, so one call feeds every proxy entity. WAN accelerators have no states endpoint, so
+those entities are configuration only.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
+INIT_PATH = COMPONENT / "__init__.py"
+SENSOR_PATH = COMPONENT / "sensor.py"
+BUTTON_PATH = COMPONENT / "button.py"
+
+
+def _load_display():
+    spec = importlib.util.spec_from_file_location("veeam_br_display", COMPONENT / "display.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # EProxyType, as reported by a real 13.1 server
+        ("GeneralPurposeProxy", "General purpose"),
+        ("ViProxy", "VMware"),
+        ("HvProxy", "Hyper-V"),
+        ("NutanixAHV", "Nutanix AHV"),
+        ("PVE", "Proxmox VE"),
+    ],
+)
+def test_proxy_types_read_like_english(raw, expected):
+    """ "ViProxy" and "PVE" tell a dashboard reader nothing on their own."""
+    assert _load_display().humanize(raw) == expected
+
+
+def test_proxies_are_fetched_from_the_states_endpoint():
+    """get_all_proxies carries configuration only; the states endpoint carries both."""
+    source = INIT_PATH.read_text(encoding="utf-8")
+
+    assert "get_all_proxies_states" in source
+    assert "proxies.get_all_proxies_states" in source, "should be pre-imported like the others"
+
+
+def test_proxy_state_flags_are_read_as_booleans_or_unknown():
+    """A missing flag must not read as False, which would claim a proxy is online."""
+    source = INIT_PATH.read_text(encoding="utf-8")
+    block = source[source.index("proxies_list = []") :]
+    block = block[: block.index("wan_accelerators_list = []")]
+
+    for flag in ("is_online", "is_disabled", "is_out_of_date"):
+        assert f'_bool_or_none(proxy, "{flag}")' in block, f"{flag} should go through the guard"
+
+
+def test_proxies_without_an_id_are_skipped():
+    """Entity unique IDs are built from it, as with jobs and repositories."""
+    source = INIT_PATH.read_text(encoding="utf-8")
+    block = source[source.index("proxies_list = []") :]
+    block = block[: block.index("wan_accelerators_list = []")]
+
+    assert "no usable ID" in block
+
+
+def test_proxy_failures_do_not_take_down_the_refresh():
+    """A proxy endpoint error should cost the proxy entities, not everything else."""
+    source = INIT_PATH.read_text(encoding="utf-8")
+    block = source[source.index("proxies_list = []") :]
+    block = block[: block.index('_LOGGER.debug("Total proxies')]
+
+    assert "Failed to parse proxies" in block
+    assert "Failed to fetch proxies" in block
+
+
+def test_wan_accelerator_optional_fields_are_guarded():
+    """server and cache are both optional in the schema, and UNSET is not None."""
+    source = INIT_PATH.read_text(encoding="utf-8")
+    block = source[source.index("wan_accelerators_list = []") :]
+    block = block[: block.index("# Fetch High Availability cluster")]
+
+    assert "has_server" in block and "has_cache" in block
+    assert "_is_unset(server)" in block and "_is_unset(cache)" in block
+
+
+def test_both_kinds_reach_the_coordinator_payload():
+    source = INIT_PATH.read_text(encoding="utf-8")
+
+    assert '"proxies": proxies_list' in source
+    assert '"wan_accelerators": wan_accelerators_list' in source
+
+
+def test_entities_are_gated_on_the_endpoint_existing():
+    """Neither endpoint is present in every API revision the library ships."""
+    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
+
+    assert 'check_api_feature_availability(api_version, "api.proxies")' in sensor_source
+    assert 'check_api_feature_availability(api_version, "api.wan_accelerators")' in sensor_source
+
+
+def test_proxy_enabled_is_reported_the_healthy_way_round():
+    """The API reports isDisabled; a sensor called "Disabled" would show red when fine."""
+    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
+    block = sensor_source[sensor_source.index("class VeeamProxyEnabledSensor") :]
+    block = block[: block.index("class VeeamProxyOutOfDate")]
+
+    assert 'self._attr_name = "Enabled"' in block
+    assert 'return not proxy["is_disabled"]' in block
+    assert 'proxy.get("is_disabled") is None' in block, "unknown must stay unknown, not True"
+
+
+def test_proxy_buttons_exist_for_both_directions():
+    button_source = BUTTON_PATH.read_text(encoding="utf-8")
+
+    assert "class VeeamProxyEnableButton" in button_source
+    assert "class VeeamProxyDisableButton" in button_source
+    assert "enable_proxy" in button_source and "disable_proxy" in button_source
+
+
+def test_proxy_buttons_are_config_entities():
+    """They change infrastructure state, so they belong with the other controls."""
+    button_source = BUTTON_PATH.read_text(encoding="utf-8")
+    block = button_source[button_source.index("class VeeamProxyButtonBase") :]
+    block = block[: block.index("class VeeamProxyEnableButton")]
+
+    assert "EntityCategory.CONFIG" in block
+
+
+def test_proxy_entities_share_one_device_per_proxy():
+    """Sensors and buttons must agree on the identifier or they split into two devices."""
+    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
+    button_source = BUTTON_PATH.read_text(encoding="utf-8")
+
+    identifier = 'f"proxy_{self._proxy_id}"'
+    assert identifier in sensor_source
+    assert identifier in button_source
+
+    for source in (sensor_source, button_source):
+        block = source[source.index(identifier) - 400 : source.index(identifier) + 400]
+        assert '"model": "Backup Proxy"' in block
+
+
+def test_new_device_kinds_can_be_pruned_and_deleted():
+    """A deleted proxy should be removable like a deleted repository."""
+    source = INIT_PATH.read_text(encoding="utf-8")
+
+    assert '"proxy_": "proxies"' in source
+    assert '"wan_": "wan_accelerators"' in source
+
+
+def test_feature_map_documents_the_new_entities():
+    source = (COMPONENT / "const.py").read_text(encoding="utf-8")
+
+    for key in ("proxy_data", "proxy_enable_button", "wan_accelerator_data"):
+        assert key in source
+
+
+def test_wan_cache_unit_comes_from_the_api():
+    """Veeam reports the unit next to the number rather than fixing it to one."""
+    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
+    block = sensor_source[sensor_source.index("class VeeamWanAcceleratorCacheSensor") :]
+
+    assert "def native_unit_of_measurement" in block
+    assert 'accelerator.get("cache_size_unit")' in block
+
+
+def test_the_real_payload_shape_is_covered():
+    """Shapes taken from a real get_all_proxies response, including the nested server block."""
+    payload = json.loads("""
+        {"data": [
+          {"server": {"hostId": "6745a759-2205-4cd2-b172-8ec8f7e60ef8",
+                      "hostName": "This server", "maxTaskCount": 2},
+           "type": "GeneralPurposeProxy",
+           "id": "50cbf622-129e-482a-9197-d67e5bb1fb1f",
+           "name": "Backup Proxy", "description": "Created by Veeam Backup & Replication"},
+          {"server": {"transportMode": "Auto", "hostId": "6745a759-2205-4cd2-b172-8ec8f7e60ef8",
+                      "hostName": "This server", "maxTaskCount": 8},
+           "type": "ViProxy",
+           "id": "18b661c1-d9dc-4233-90a0-7e7b10dc2d09",
+           "name": "VMware Backup Proxy", "description": "Created by Veeam Backup & Replication"}
+        ]}
+        """)
+    humanize = _load_display().humanize
+
+    labels = [humanize(item["type"]) for item in payload["data"]]
+    assert labels == ["General purpose", "VMware"]
+
+    # Both proxies sit on the same host, so the device name has to come from the proxy name
+    hosts = {item["server"]["hostName"] for item in payload["data"]}
+    assert len(hosts) == 1
+    assert len({item["name"] for item in payload["data"]}) == 2


### PR DESCRIPTION
A device per backup proxy, from get_all_proxies_states — which carries the configuration as well as the live state, so one call feeds every entity: Online, Enabled, Out Of Date, and a Type sensor holding the host and description as attributes. Plus Enable and Disable buttons, which is how an operator takes a proxy out of service while working on its host.

Enabled rather than Disabled is deliberate: the API reports isDisabled, and a sensor spelled that way shows a problem colour when everything is fine. An unknown flag stays unknown rather than becoming a confident "online".

A device per WAN accelerator too. There is no states endpoint for those, so it is configuration only: cache size, with the cache folder, traffic port, stream count and high-bandwidth mode as attributes. The unit comes from the API rather than being assumed, since Veeam reports it next to the number.

Proxy types get labels — GeneralPurposeProxy, ViProxy, HvProxy, NutanixAHV and PVE are opaque on a dashboard, and "PVE" in particular tells you nothing unless you already know it means Proxmox VE.

Both kinds are registered as prunable device kinds, so a deleted proxy can be removed like a deleted repository, and both are gated on the endpoint existing in the configured API revision.

Also adds a proxy_offline blueprint. A proxy going offline does not fail jobs — Veeam reassigns the work — so it tends to go unnoticed until backups slow down. It waits out a configurable period so a host restart is not an alert, and can ignore proxies that are disabled on purpose.