### PR TITLE
Move the binary sensors onto the binary_sensor platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,19 @@ no credentials.
 
 ## Entity States
 
+### Binary sensors
+
+Online, enabled, out-of-date and similar yes/no readings are `binary_sensor` entities with a
+device class, so Home Assistant renders them in words — *Connected* / *Disconnected*,
+*OK* / *Problem*, *Running* / *Not running* — rather than as `on` / `off`.
+
+> [!IMPORTANT]
+> Before 0.6.0 these were created as `sensor.*` entities and displayed as raw `on`/`off`. On
+> upgrade each one is replaced by its `binary_sensor.*` equivalent and the old entity is removed.
+> Automations, dashboards and templates referring to the old `sensor.` entity IDs need updating —
+> the entity name is unchanged, only the domain moved. Each replacement is logged.
+
+
 Values that the REST API reports as identifiers are shown as readable labels:
 `EnterprisePlus` becomes *Enterprise Plus*, `ProxmoxBackupJob` becomes *Proxmox Backup Job*,
 `WinLocal` becomes *Windows (local)*, and `inactive` becomes *Inactive*. Job status is lower
@@ -503,7 +516,8 @@ The integration monitors the following Veeam objects:
 ### Supported Entities
 
 - **Sensors**: Status, type, timestamps, capacity, statistics
-- **Binary Sensors**: Online/offline, connectivity, update available
+- **Binary Sensors**: Online/offline, connectivity, update available, immutability, capacity
+  warnings, proxy state (in the `binary_sensor` domain, so they read as words)
 - **Buttons**: Repository rescan, extent maintenance/sealed mode, start/stop/enable/disable job
 
 ### Unsupported (Future Enhancements)

--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -35,7 +35,7 @@ from .sdk_patches import patch_models as patch_null_values_in_models
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.BUTTON]
 
 # High Availability cluster endpoints exist only from API 1.3-rev2 (VBR 13.1)
 HA_CLUSTER_FEATURE = "api.high_availability_ha_cluster"

--- a/custom_components/veeam_br/binary_sensor.py
+++ b/custom_components/veeam_br/binary_sensor.py
@@ -1,0 +1,624 @@
+"""Binary sensors for Veeam Backup & Replication.
+
+These live in their own platform rather than alongside the sensors on purpose. Home Assistant
+derives an entity domain from the platform that creates it, so a BinarySensorEntity added by the
+sensor platform lands in the sensor domain — where the binary-sensor device class wording never
+applies and every state displays as a raw "on"/"off". In the binary_sensor domain the same
+entities read as Connected/Disconnected, OK/Problem and Running/Not running.
+
+Entities that existed under the sensor domain are removed as their replacements are created, so
+one upgrade moves them rather than leaving two of everything.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, check_api_feature_availability, configured_api_version
+from .sensor import (
+    VeeamHAClusterMixin,
+    VeeamLicenseMixin,
+    VeeamProxyMixin,
+    VeeamRepositoryMixin,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1
+
+
+def _drop_superseded_sensor_entities(hass: HomeAssistant, entry: ConfigEntry, entities) -> None:
+    """Remove the sensor-domain entities these binary sensors replace.
+
+    Matching is by unique ID, which is unchanged — only the domain moves. Without this an
+    upgrade would leave the old sensor.* entities behind as unavailable strays, since nothing
+    provides them any more.
+    """
+    registry = er.async_get(hass)
+    unique_ids = {entity.unique_id for entity in entities if entity.unique_id}
+
+    for existing in list(er.async_entries_for_config_entry(registry, entry.entry_id)):
+        if existing.domain != "sensor" or existing.unique_id not in unique_ids:
+            continue
+        _LOGGER.info(
+            "Replacing %s with its binary_sensor equivalent; update any automation or "
+            "dashboard that referenced it",
+            existing.entity_id,
+        )
+        registry.async_remove(existing.entity_id)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Veeam binary sensors."""
+    coordinator = entry.runtime_data["coordinator"]
+
+    added_repository_ids: set[str] = set()
+    added_proxy_ids: set[str] = set()
+    server_added = False
+    license_added = False
+    ha_cluster_added = False
+
+    @callback
+    def _sync_entities() -> None:
+        nonlocal server_added
+        nonlocal license_added
+        nonlocal ha_cluster_added
+
+        if not coordinator.data:
+            return
+
+        api_version = configured_api_version(entry)
+        new_entities: list[BinarySensorEntity] = []
+
+        if check_api_feature_availability(api_version, "api.repositories"):
+            for repository in coordinator.data.get("repositories", []):
+                repo_id = repository.get("id")
+                if not repo_id or repo_id in added_repository_ids:
+                    continue
+
+                new_entities.extend(
+                    [
+                        VeeamRepositoryOnlineStatusSensor(coordinator, entry, repository),
+                        VeeamRepositoryOutOfDateSensor(coordinator, entry, repository),
+                        VeeamRepositoryImmutableSensor(coordinator, entry, repository),
+                        VeeamRepositoryAccessibleSensor(coordinator, entry, repository),
+                        VeeamRepositoryCapacityWarningSensor(coordinator, entry, repository),
+                        VeeamRepositoryCapacityCriticalSensor(coordinator, entry, repository),
+                    ]
+                )
+                added_repository_ids.add(repo_id)
+
+        if check_api_feature_availability(api_version, "api.proxies"):
+            for proxy in coordinator.data.get("proxies", []):
+                proxy_id = proxy.get("id")
+                if not proxy_id or proxy_id in added_proxy_ids:
+                    continue
+
+                new_entities.extend(
+                    [
+                        VeeamProxyOnlineSensor(coordinator, entry, proxy),
+                        VeeamProxyEnabledSensor(coordinator, entry, proxy),
+                        VeeamProxyOutOfDateSensor(coordinator, entry, proxy),
+                    ]
+                )
+                added_proxy_ids.add(proxy_id)
+
+        if (
+            not server_added
+            and coordinator.data.get("server_info")
+            and check_api_feature_availability(api_version, "api.service")
+        ):
+            new_entities.extend(
+                [
+                    VeeamServerHealthOkSensor(coordinator, entry),
+                    VeeamServerConnectedSensor(coordinator, entry),
+                ]
+            )
+            server_added = True
+
+        if (
+            not license_added
+            and coordinator.data.get("license_info")
+            and check_api_feature_availability(api_version, "api.license_")
+        ):
+            new_entities.extend(
+                [
+                    VeeamLicenseAutoUpdateSensor(coordinator, entry),
+                    VeeamLicenseCloudConnectSensor(coordinator, entry),
+                ]
+            )
+            license_added = True
+
+        if (
+            not ha_cluster_added
+            and coordinator.data.get("ha_cluster")
+            and check_api_feature_availability(api_version, "api.high_availability_ha_cluster")
+        ):
+            new_entities.extend(
+                [
+                    VeeamHAClusterOnlineSensor(coordinator, entry),
+                    VeeamHAClusterFailoverInProgressSensor(coordinator, entry),
+                    VeeamHAClusterMaintenanceSensor(coordinator, entry),
+                ]
+            )
+            ha_cluster_added = True
+
+        if new_entities:
+            _drop_superseded_sensor_entities(hass, entry, new_entities)
+            _LOGGER.debug("Adding %d Veeam binary sensors", len(new_entities))
+            async_add_entities(new_entities)
+
+    _sync_entities()
+    coordinator.async_add_listener(_sync_entities)
+
+
+class VeeamServerBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
+    """Base class for Veeam Server binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+
+    def _server_info(self) -> dict[str, Any] | None:
+        return self.coordinator.data.get("server_info") if self.coordinator.data else None
+
+    @property
+    def device_info(self):
+        """Return device info for the Veeam server."""
+        server_info = self._server_info()
+        # Fall back to the configured host rather than a bare "Unknown": when server info
+        # fails to fetch, every entry's device would otherwise carry the same name (#82)
+        host = self._config_entry.data.get(CONF_HOST, "Unknown")
+        server_name = (server_info.get("name") if server_info else None) or host
+        return {
+            "identifiers": {(DOMAIN, f"server_{self._config_entry.entry_id}")},
+            "name": f"{server_name}",
+            "manufacturer": "Veeam",
+            "model": "Backup & Replication Server",
+        }
+
+
+class VeeamLicenseBinarySensorBase(VeeamLicenseMixin, CoordinatorEntity, BinarySensorEntity):
+    """Base class for Veeam License binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamLicenseMixin.__init__(self, coordinator, config_entry)
+
+
+class VeeamRepositoryBinarySensorBase(VeeamRepositoryMixin, CoordinatorEntity, BinarySensorEntity):
+    """Base class for Veeam Repository binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry, repository_data):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamRepositoryMixin.__init__(self, coordinator, config_entry, repository_data)
+
+    def _get_free_space_percent(self) -> float | None:
+        """Calculate free space percentage for the repository.
+
+        Free space is calculated as (capacity - used) / capacity * 100
+        to get the actual available space percentage.
+        """
+        repo = self._repository()
+        if not repo:
+            return None
+        capacity = repo.get("capacity_gb")
+        used = repo.get("used_space_gb")
+        if capacity and capacity > 0 and used is not None:
+            free = capacity - used
+            return (free / capacity) * 100
+        return None
+
+
+class VeeamHAClusterBinarySensorBase(VeeamHAClusterMixin, CoordinatorEntity, BinarySensorEntity):
+    """Base class for HA cluster binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamHAClusterMixin.__init__(self, coordinator, config_entry)
+
+
+class VeeamProxyBinarySensorBase(VeeamProxyMixin, CoordinatorEntity, BinarySensorEntity):
+    """Base class for proxy binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        CoordinatorEntity.__init__(self, coordinator)
+        VeeamProxyMixin.__init__(self, coordinator, config_entry, proxy_data)
+
+
+class VeeamServerHealthOkSensor(VeeamServerBinarySensorBase):
+    """Binary sensor for Veeam Server Health."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_server_health_ok"
+        self._attr_name = "Health OK"
+
+    @property
+    def is_on(self) -> bool | None:
+        # Health reflects the current update status
+        return self.coordinator.last_update_success
+
+    @property
+    def icon(self) -> str:
+        return "mdi:heart-pulse" if self.is_on else "mdi:heart-off"
+
+
+class VeeamServerConnectedSensor(VeeamServerBinarySensorBase):
+    """Binary sensor for Veeam Server Connection Status."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_server_connected"
+        self._attr_name = "Connected"
+
+    @property
+    def is_on(self) -> bool | None:
+        # Connection status reflects the current update status
+        return self.coordinator.last_update_success
+
+    @property
+    def icon(self) -> str:
+        return "mdi:lan-connect" if self.is_on else "mdi:lan-disconnect"
+
+
+# ===========================
+# LICENSE SENSORS (single device)
+# ===========================
+
+
+class VeeamLicenseAutoUpdateSensor(VeeamLicenseBinarySensorBase):
+    """Binary sensor for Veeam License Auto Update."""
+
+    _attr_device_class = BinarySensorDeviceClass.UPDATE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_license_auto_update"
+        self._attr_name = "Auto Update Enabled"
+
+    @property
+    def is_on(self) -> bool | None:
+        license_info = self._license_info()
+        if not license_info:
+            return None
+        value = license_info.get("auto_update_enabled")
+        if value is None:
+            return None
+        return bool(value)
+
+    @property
+    def icon(self) -> str:
+        return "mdi:update"
+
+
+class VeeamLicenseCloudConnectSensor(VeeamLicenseBinarySensorBase):
+    """Binary sensor for Veeam License Cloud Connect."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_license_cloud_connect"
+        self._attr_name = "Cloud Connect Enabled"
+
+    @property
+    def is_on(self) -> bool | None:
+        license_info = self._license_info()
+        if not license_info:
+            return None
+        cloud_connect = license_info.get("cloud_connect")
+        if cloud_connect is None:
+            return None
+        # cloud_connect is an enum string (e.g., "Enabled", "Disabled"), not a boolean
+        return str(cloud_connect).lower() == "enabled"
+
+    @property
+    def icon(self) -> str:
+        return "mdi:cloud-check" if self.is_on else "mdi:cloud-off"
+
+
+# ===========================
+# REPOSITORY SENSORS (device per repository)
+# ===========================
+
+
+class VeeamRepositoryOnlineStatusSensor(VeeamRepositoryBinarySensorBase):
+    """Binary sensor for Veeam Repository Online Status."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, repository_data):
+        super().__init__(coordinator, config_entry, repository_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_online"
+        self._attr_name = "Online"
+
+    @property
+    def is_on(self) -> bool | None:
+        repo = self._repository()
+        if not repo:
+            return None
+        value = repo.get("is_online")
+        if value is None:
+            return None
+        return bool(value)
+
+    @property
+    def icon(self) -> str:
+        return "mdi:check-network" if self.is_on else "mdi:close-network"
+
+
+class VeeamRepositoryOutOfDateSensor(VeeamRepositoryBinarySensorBase):
+    """Binary sensor for Veeam Repository Out of Date Status."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, repository_data):
+        super().__init__(coordinator, config_entry, repository_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_out_of_date"
+        self._attr_name = "Out of Date"
+
+    @property
+    def is_on(self) -> bool | None:
+        repo = self._repository()
+        if not repo:
+            return None
+        value = repo.get("is_out_of_date")
+        if value is None:
+            return None
+        return bool(value)
+
+    @property
+    def icon(self) -> str:
+        return "mdi:alert-octagon" if self.is_on else "mdi:check-decagram"
+
+
+class VeeamRepositoryImmutableSensor(VeeamRepositoryBinarySensorBase):
+    """Binary sensor for Veeam Repository Immutability."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, repository_data):
+        super().__init__(coordinator, config_entry, repository_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_immutable"
+        self._attr_name = "Immutable"
+
+    @property
+    def is_on(self) -> bool | None:
+        repo = self._repository()
+        if not repo:
+            return None
+        value = repo.get("is_immutable")
+        if value is None:
+            return None
+        return bool(value)
+
+    @property
+    def icon(self) -> str:
+        return "mdi:lock" if self.is_on else "mdi:lock-open"
+
+
+class VeeamRepositoryAccessibleSensor(VeeamRepositoryBinarySensorBase):
+    """Binary sensor for Veeam Repository Accessible status."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, repository_data):
+        super().__init__(coordinator, config_entry, repository_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_accessible"
+        self._attr_name = "Accessible"
+
+    @property
+    def is_on(self) -> bool | None:
+        repo = self._repository()
+        if not repo:
+            return None
+        value = repo.get("is_accessible")
+        if value is None:
+            return None
+        return bool(value)
+
+    @property
+    def icon(self) -> str:
+        return "mdi:folder-open" if self.is_on else "mdi:folder-lock"
+
+
+class VeeamRepositoryCapacityWarningSensor(VeeamRepositoryBinarySensorBase):
+    """Binary sensor for Veeam Repository Capacity Warning (< 15% free)."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator, config_entry, repository_data):
+        super().__init__(coordinator, config_entry, repository_data)
+        self._attr_unique_id = (
+            f"{config_entry.entry_id}_repository_{self._repo_id}_capacity_warning"
+        )
+        self._attr_name = "Capacity Warning"
+
+    @property
+    def is_on(self) -> bool | None:
+        free_percent = self._get_free_space_percent()
+        if free_percent is None:
+            return None
+        return free_percent < 15
+
+    @property
+    def icon(self) -> str:
+        return "mdi:alert" if self.is_on else "mdi:check-circle"
+
+
+class VeeamRepositoryCapacityCriticalSensor(VeeamRepositoryBinarySensorBase):
+    """Binary sensor for Veeam Repository Capacity Critical (< 5% free)."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator, config_entry, repository_data):
+        super().__init__(coordinator, config_entry, repository_data)
+        self._attr_unique_id = (
+            f"{config_entry.entry_id}_repository_{self._repo_id}_capacity_critical"
+        )
+        self._attr_name = "Capacity Critical"
+
+    @property
+    def is_on(self) -> bool | None:
+        free_percent = self._get_free_space_percent()
+        if free_percent is None:
+            return None
+        return free_percent < 5
+
+    @property
+    def icon(self) -> str:
+        return "mdi:alert-circle" if self.is_on else "mdi:check-circle"
+
+
+# ===========================
+# SOBR SENSORS (device per SOBR)
+# ===========================
+
+
+class VeeamHAClusterOnlineSensor(VeeamHAClusterBinarySensorBase):
+    """Binary sensor for whether the HA cluster is online."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_online"
+        self._attr_name = "Online"
+
+    @property
+    def is_on(self) -> bool | None:
+        cluster = self._cluster()
+        return cluster.get("is_online") if cluster else None
+
+
+class VeeamHAClusterFailoverInProgressSensor(VeeamHAClusterBinarySensorBase):
+    """Binary sensor for an in-progress failover."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_failover_in_progress"
+        self._attr_name = "Failover In Progress"
+
+    @property
+    def is_on(self) -> bool | None:
+        cluster = self._cluster()
+        return cluster.get("is_failover_in_progress") if cluster else None
+
+    @property
+    def icon(self) -> str:
+        return "mdi:swap-horizontal-bold" if self.is_on else "mdi:swap-horizontal"
+
+
+class VeeamHAClusterMaintenanceSensor(VeeamHAClusterBinarySensorBase):
+    """Binary sensor for cluster maintenance mode."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_maintenance"
+        self._attr_name = "Maintenance In Progress"
+
+    @property
+    def is_on(self) -> bool | None:
+        cluster = self._cluster()
+        return cluster.get("is_maintenance_in_progress") if cluster else None
+
+    @property
+    def icon(self) -> str:
+        return "mdi:wrench-clock" if self.is_on else "mdi:wrench"
+
+
+class VeeamProxyOnlineSensor(VeeamProxyBinarySensorBase):
+    """Binary sensor for whether a proxy is online."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        super().__init__(coordinator, config_entry, proxy_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_online"
+        self._attr_name = "Online"
+
+    @property
+    def is_on(self) -> bool | None:
+        proxy = self._proxy()
+        return proxy.get("is_online") if proxy else None
+
+
+class VeeamProxyEnabledSensor(VeeamProxyBinarySensorBase):
+    """Binary sensor for whether a proxy is enabled.
+
+    Reported as enabled rather than disabled, so "on" is the healthy state and the tile colour
+    matches every other sensor here.
+    """
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        super().__init__(coordinator, config_entry, proxy_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_enabled"
+        self._attr_name = "Enabled"
+
+    @property
+    def is_on(self) -> bool | None:
+        proxy = self._proxy()
+        if not proxy or proxy.get("is_disabled") is None:
+            return None
+        return not proxy["is_disabled"]
+
+    @property
+    def icon(self) -> str:
+        return "mdi:play-circle" if self.is_on else "mdi:pause-circle"
+
+
+class VeeamProxyOutOfDateSensor(VeeamProxyBinarySensorBase):
+    """Binary sensor for a proxy running outdated components."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, config_entry, proxy_data):
+        super().__init__(coordinator, config_entry, proxy_data)
+        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_out_of_date"
+        self._attr_name = "Out Of Date"
+
+    @property
+    def is_on(self) -> bool | None:
+        proxy = self._proxy()
+        return proxy.get("is_out_of_date") if proxy else None

--- a/custom_components/veeam_br/binary_sensor.py
+++ b/custom_components/veeam_br/binary_sensor.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import CONF_HOST, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/veeam_br/sensor.py
+++ b/custom_components/veeam_br/sensor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, EntityCategory
@@ -95,12 +94,6 @@ async def async_setup_entry(
                         VeeamRepositoryFreeSpaceSensor(coordinator, entry, repository),
                         VeeamRepositoryUsedSpaceSensor(coordinator, entry, repository),
                         VeeamRepositoryUsedSpacePercentSensor(coordinator, entry, repository),
-                        VeeamRepositoryOnlineStatusSensor(coordinator, entry, repository),
-                        VeeamRepositoryOutOfDateSensor(coordinator, entry, repository),
-                        VeeamRepositoryImmutableSensor(coordinator, entry, repository),
-                        VeeamRepositoryAccessibleSensor(coordinator, entry, repository),
-                        VeeamRepositoryCapacityWarningSensor(coordinator, entry, repository),
-                        VeeamRepositoryCapacityCriticalSensor(coordinator, entry, repository),
                     ]
                 )
 
@@ -147,9 +140,6 @@ async def async_setup_entry(
 
                 new_entities.extend(
                     [
-                        VeeamProxyOnlineSensor(coordinator, entry, proxy),
-                        VeeamProxyEnabledSensor(coordinator, entry, proxy),
-                        VeeamProxyOutOfDateSensor(coordinator, entry, proxy),
                         VeeamProxyTypeSensor(coordinator, entry, proxy),
                     ]
                 )
@@ -182,9 +172,7 @@ async def async_setup_entry(
                     VeeamServerDatabaseVendorSensor(coordinator, entry),
                     VeeamServerSQLEditionSensor(coordinator, entry),
                     VeeamServerSQLVersionSensor(coordinator, entry),
-                    VeeamServerHealthOkSensor(coordinator, entry),
                     VeeamServerLastSuccessfulPollSensor(coordinator, entry),
-                    VeeamServerConnectedSensor(coordinator, entry),
                 ]
             )
             server_added = True
@@ -205,8 +193,6 @@ async def async_setup_entry(
                     VeeamLicenseSupportExpirationSensor(coordinator, entry),
                     VeeamLicenseLicensedToSensor(coordinator, entry),
                     VeeamLicenseSupportIDSensor(coordinator, entry),
-                    VeeamLicenseAutoUpdateSensor(coordinator, entry),
-                    VeeamLicenseCloudConnectSensor(coordinator, entry),
                 ]
             )
 
@@ -231,9 +217,6 @@ async def async_setup_entry(
         ):
             new_entities.extend(
                 [
-                    VeeamHAClusterOnlineSensor(coordinator, entry),
-                    VeeamHAClusterFailoverInProgressSensor(coordinator, entry),
-                    VeeamHAClusterMaintenanceSensor(coordinator, entry),
                     VeeamHAClusterLastOnlineSensor(coordinator, entry),
                     VeeamHAClusterEndpointSensor(coordinator, entry),
                 ]
@@ -767,81 +750,6 @@ class VeeamServerLastSuccessfulPollSensor(VeeamServerBaseSensor):
         return "mdi:clock-check"
 
 
-class VeeamServerBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
-    """Base class for Veeam Server binary sensors."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator)
-        self._config_entry = config_entry
-
-    def _server_info(self) -> dict[str, Any] | None:
-        return self.coordinator.data.get("server_info") if self.coordinator.data else None
-
-    @property
-    def device_info(self):
-        """Return device info for the Veeam server."""
-        server_info = self._server_info()
-        # Fall back to the configured host rather than a bare "Unknown": when server info
-        # fails to fetch, every entry's device would otherwise carry the same name (#82)
-        host = self._config_entry.data.get(CONF_HOST, "Unknown")
-        server_name = (server_info.get("name") if server_info else None) or host
-        return {
-            "identifiers": {(DOMAIN, f"server_{self._config_entry.entry_id}")},
-            "name": f"{server_name}",
-            "manufacturer": "Veeam",
-            "model": "Backup & Replication Server",
-        }
-
-
-class VeeamServerHealthOkSensor(VeeamServerBinarySensorBase):
-    """Binary sensor for Veeam Server Health."""
-
-    _attr_device_class = BinarySensorDeviceClass.RUNNING
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator, config_entry)
-        self._attr_unique_id = f"{config_entry.entry_id}_server_health_ok"
-        self._attr_name = "Health OK"
-
-    @property
-    def is_on(self) -> bool | None:
-        # Health reflects the current update status
-        return self.coordinator.last_update_success
-
-    @property
-    def icon(self) -> str:
-        return "mdi:heart-pulse" if self.is_on else "mdi:heart-off"
-
-
-class VeeamServerConnectedSensor(VeeamServerBinarySensorBase):
-    """Binary sensor for Veeam Server Connection Status."""
-
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator, config_entry)
-        self._attr_unique_id = f"{config_entry.entry_id}_server_connected"
-        self._attr_name = "Connected"
-
-    @property
-    def is_on(self) -> bool | None:
-        # Connection status reflects the current update status
-        return self.coordinator.last_update_success
-
-    @property
-    def icon(self) -> str:
-        return "mdi:lan-connect" if self.is_on else "mdi:lan-disconnect"
-
-
-# ===========================
-# LICENSE SENSORS (single device)
-# ===========================
-
-
 class VeeamLicenseBaseSensor(VeeamLicenseMixin, CoordinatorEntity, SensorEntity):
     """Base class for Veeam License sensors."""
 
@@ -1005,74 +913,6 @@ class VeeamLicenseSupportIDSensor(VeeamLicenseBaseSensor):
     @property
     def icon(self) -> str:
         return "mdi:identifier"
-
-
-class VeeamLicenseBinarySensorBase(VeeamLicenseMixin, CoordinatorEntity, BinarySensorEntity):
-    """Base class for Veeam License binary sensors."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, coordinator, config_entry):
-        CoordinatorEntity.__init__(self, coordinator)
-        VeeamLicenseMixin.__init__(self, coordinator, config_entry)
-
-
-class VeeamLicenseAutoUpdateSensor(VeeamLicenseBinarySensorBase):
-    """Binary sensor for Veeam License Auto Update."""
-
-    _attr_device_class = BinarySensorDeviceClass.UPDATE
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator, config_entry)
-        self._attr_unique_id = f"{config_entry.entry_id}_license_auto_update"
-        self._attr_name = "Auto Update Enabled"
-
-    @property
-    def is_on(self) -> bool | None:
-        license_info = self._license_info()
-        if not license_info:
-            return None
-        value = license_info.get("auto_update_enabled")
-        if value is None:
-            return None
-        return bool(value)
-
-    @property
-    def icon(self) -> str:
-        return "mdi:update"
-
-
-class VeeamLicenseCloudConnectSensor(VeeamLicenseBinarySensorBase):
-    """Binary sensor for Veeam License Cloud Connect."""
-
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator, config_entry)
-        self._attr_unique_id = f"{config_entry.entry_id}_license_cloud_connect"
-        self._attr_name = "Cloud Connect Enabled"
-
-    @property
-    def is_on(self) -> bool | None:
-        license_info = self._license_info()
-        if not license_info:
-            return None
-        cloud_connect = license_info.get("cloud_connect")
-        if cloud_connect is None:
-            return None
-        # cloud_connect is an enum string (e.g., "Enabled", "Disabled"), not a boolean
-        return str(cloud_connect).lower() == "enabled"
-
-    @property
-    def icon(self) -> str:
-        return "mdi:cloud-check" if self.is_on else "mdi:cloud-off"
-
-
-# ===========================
-# REPOSITORY SENSORS (device per repository)
-# ===========================
 
 
 class VeeamRepositoryBaseSensor(VeeamRepositoryMixin, CoordinatorEntity, SensorEntity):
@@ -1250,109 +1090,6 @@ class VeeamRepositoryUsedSpacePercentSensor(VeeamRepositoryBaseSensor):
         return "mdi:chart-arc"
 
 
-class VeeamRepositoryBinarySensorBase(VeeamRepositoryMixin, CoordinatorEntity, BinarySensorEntity):
-    """Base class for Veeam Repository binary sensors."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, coordinator, config_entry, repository_data):
-        CoordinatorEntity.__init__(self, coordinator)
-        VeeamRepositoryMixin.__init__(self, coordinator, config_entry, repository_data)
-
-    def _get_free_space_percent(self) -> float | None:
-        """Calculate free space percentage for the repository.
-
-        Free space is calculated as (capacity - used) / capacity * 100
-        to get the actual available space percentage.
-        """
-        repo = self._repository()
-        if not repo:
-            return None
-        capacity = repo.get("capacity_gb")
-        used = repo.get("used_space_gb")
-        if capacity and capacity > 0 and used is not None:
-            free = capacity - used
-            return (free / capacity) * 100
-        return None
-
-
-class VeeamRepositoryOnlineStatusSensor(VeeamRepositoryBinarySensorBase):
-    """Binary sensor for Veeam Repository Online Status."""
-
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry, repository_data):
-        super().__init__(coordinator, config_entry, repository_data)
-        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_online"
-        self._attr_name = "Online"
-
-    @property
-    def is_on(self) -> bool | None:
-        repo = self._repository()
-        if not repo:
-            return None
-        value = repo.get("is_online")
-        if value is None:
-            return None
-        return bool(value)
-
-    @property
-    def icon(self) -> str:
-        return "mdi:check-network" if self.is_on else "mdi:close-network"
-
-
-class VeeamRepositoryOutOfDateSensor(VeeamRepositoryBinarySensorBase):
-    """Binary sensor for Veeam Repository Out of Date Status."""
-
-    _attr_device_class = BinarySensorDeviceClass.PROBLEM
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry, repository_data):
-        super().__init__(coordinator, config_entry, repository_data)
-        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_out_of_date"
-        self._attr_name = "Out of Date"
-
-    @property
-    def is_on(self) -> bool | None:
-        repo = self._repository()
-        if not repo:
-            return None
-        value = repo.get("is_out_of_date")
-        if value is None:
-            return None
-        return bool(value)
-
-    @property
-    def icon(self) -> str:
-        return "mdi:alert-octagon" if self.is_on else "mdi:check-decagram"
-
-
-class VeeamRepositoryImmutableSensor(VeeamRepositoryBinarySensorBase):
-    """Binary sensor for Veeam Repository Immutability."""
-
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry, repository_data):
-        super().__init__(coordinator, config_entry, repository_data)
-        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_immutable"
-        self._attr_name = "Immutable"
-
-    @property
-    def is_on(self) -> bool | None:
-        repo = self._repository()
-        if not repo:
-            return None
-        value = repo.get("is_immutable")
-        if value is None:
-            return None
-        return bool(value)
-
-    @property
-    def icon(self) -> str:
-        return "mdi:lock" if self.is_on else "mdi:lock-open"
-
-
 class VeeamRepositoryImmutabilityDaysSensor(VeeamRepositoryBaseSensor):
     """Sensor for Veeam Repository Immutability Days."""
 
@@ -1376,85 +1113,6 @@ class VeeamRepositoryImmutabilityDaysSensor(VeeamRepositoryBaseSensor):
     @property
     def icon(self) -> str:
         return "mdi:calendar-lock"
-
-
-class VeeamRepositoryAccessibleSensor(VeeamRepositoryBinarySensorBase):
-    """Binary sensor for Veeam Repository Accessible status."""
-
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry, repository_data):
-        super().__init__(coordinator, config_entry, repository_data)
-        self._attr_unique_id = f"{config_entry.entry_id}_repository_{self._repo_id}_accessible"
-        self._attr_name = "Accessible"
-
-    @property
-    def is_on(self) -> bool | None:
-        repo = self._repository()
-        if not repo:
-            return None
-        value = repo.get("is_accessible")
-        if value is None:
-            return None
-        return bool(value)
-
-    @property
-    def icon(self) -> str:
-        return "mdi:folder-open" if self.is_on else "mdi:folder-lock"
-
-
-class VeeamRepositoryCapacityWarningSensor(VeeamRepositoryBinarySensorBase):
-    """Binary sensor for Veeam Repository Capacity Warning (< 15% free)."""
-
-    _attr_device_class = BinarySensorDeviceClass.PROBLEM
-
-    def __init__(self, coordinator, config_entry, repository_data):
-        super().__init__(coordinator, config_entry, repository_data)
-        self._attr_unique_id = (
-            f"{config_entry.entry_id}_repository_{self._repo_id}_capacity_warning"
-        )
-        self._attr_name = "Capacity Warning"
-
-    @property
-    def is_on(self) -> bool | None:
-        free_percent = self._get_free_space_percent()
-        if free_percent is None:
-            return None
-        return free_percent < 15
-
-    @property
-    def icon(self) -> str:
-        return "mdi:alert" if self.is_on else "mdi:check-circle"
-
-
-class VeeamRepositoryCapacityCriticalSensor(VeeamRepositoryBinarySensorBase):
-    """Binary sensor for Veeam Repository Capacity Critical (< 5% free)."""
-
-    _attr_device_class = BinarySensorDeviceClass.PROBLEM
-
-    def __init__(self, coordinator, config_entry, repository_data):
-        super().__init__(coordinator, config_entry, repository_data)
-        self._attr_unique_id = (
-            f"{config_entry.entry_id}_repository_{self._repo_id}_capacity_critical"
-        )
-        self._attr_name = "Capacity Critical"
-
-    @property
-    def is_on(self) -> bool | None:
-        free_percent = self._get_free_space_percent()
-        if free_percent is None:
-            return None
-        return free_percent < 5
-
-    @property
-    def icon(self) -> str:
-        return "mdi:alert-circle" if self.is_on else "mdi:check-circle"
-
-
-# ===========================
-# SOBR SENSORS (device per SOBR)
-# ===========================
 
 
 class VeeamSOBRMixin:
@@ -1588,73 +1246,6 @@ class VeeamHAClusterBaseSensor(VeeamHAClusterMixin, CoordinatorEntity, SensorEnt
     def __init__(self, coordinator, config_entry):
         CoordinatorEntity.__init__(self, coordinator)
         VeeamHAClusterMixin.__init__(self, coordinator, config_entry)
-
-
-class VeeamHAClusterBinarySensorBase(VeeamHAClusterMixin, CoordinatorEntity, BinarySensorEntity):
-    """Base class for HA cluster binary sensors."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, coordinator, config_entry):
-        CoordinatorEntity.__init__(self, coordinator)
-        VeeamHAClusterMixin.__init__(self, coordinator, config_entry)
-
-
-class VeeamHAClusterOnlineSensor(VeeamHAClusterBinarySensorBase):
-    """Binary sensor for whether the HA cluster is online."""
-
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator, config_entry)
-        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_online"
-        self._attr_name = "Online"
-
-    @property
-    def is_on(self) -> bool | None:
-        cluster = self._cluster()
-        return cluster.get("is_online") if cluster else None
-
-
-class VeeamHAClusterFailoverInProgressSensor(VeeamHAClusterBinarySensorBase):
-    """Binary sensor for an in-progress failover."""
-
-    _attr_device_class = BinarySensorDeviceClass.RUNNING
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator, config_entry)
-        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_failover_in_progress"
-        self._attr_name = "Failover In Progress"
-
-    @property
-    def is_on(self) -> bool | None:
-        cluster = self._cluster()
-        return cluster.get("is_failover_in_progress") if cluster else None
-
-    @property
-    def icon(self) -> str:
-        return "mdi:swap-horizontal-bold" if self.is_on else "mdi:swap-horizontal"
-
-
-class VeeamHAClusterMaintenanceSensor(VeeamHAClusterBinarySensorBase):
-    """Binary sensor for cluster maintenance mode."""
-
-    _attr_device_class = BinarySensorDeviceClass.RUNNING
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry):
-        super().__init__(coordinator, config_entry)
-        self._attr_unique_id = f"{config_entry.entry_id}_ha_cluster_maintenance"
-        self._attr_name = "Maintenance In Progress"
-
-    @property
-    def is_on(self) -> bool | None:
-        cluster = self._cluster()
-        return cluster.get("is_maintenance_in_progress") if cluster else None
-
-    @property
-    def icon(self) -> str:
-        return "mdi:wrench-clock" if self.is_on else "mdi:wrench"
 
 
 class VeeamHAClusterLastOnlineSensor(VeeamHAClusterBaseSensor):
@@ -1957,73 +1548,6 @@ class VeeamProxyBaseSensor(VeeamProxyMixin, CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator, config_entry, proxy_data):
         CoordinatorEntity.__init__(self, coordinator)
         VeeamProxyMixin.__init__(self, coordinator, config_entry, proxy_data)
-
-
-class VeeamProxyBinarySensorBase(VeeamProxyMixin, CoordinatorEntity, BinarySensorEntity):
-    """Base class for proxy binary sensors."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, coordinator, config_entry, proxy_data):
-        CoordinatorEntity.__init__(self, coordinator)
-        VeeamProxyMixin.__init__(self, coordinator, config_entry, proxy_data)
-
-
-class VeeamProxyOnlineSensor(VeeamProxyBinarySensorBase):
-    """Binary sensor for whether a proxy is online."""
-
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-
-    def __init__(self, coordinator, config_entry, proxy_data):
-        super().__init__(coordinator, config_entry, proxy_data)
-        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_online"
-        self._attr_name = "Online"
-
-    @property
-    def is_on(self) -> bool | None:
-        proxy = self._proxy()
-        return proxy.get("is_online") if proxy else None
-
-
-class VeeamProxyEnabledSensor(VeeamProxyBinarySensorBase):
-    """Binary sensor for whether a proxy is enabled.
-
-    Reported as enabled rather than disabled, so "on" is the healthy state and the tile colour
-    matches every other sensor here.
-    """
-
-    def __init__(self, coordinator, config_entry, proxy_data):
-        super().__init__(coordinator, config_entry, proxy_data)
-        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_enabled"
-        self._attr_name = "Enabled"
-
-    @property
-    def is_on(self) -> bool | None:
-        proxy = self._proxy()
-        if not proxy or proxy.get("is_disabled") is None:
-            return None
-        return not proxy["is_disabled"]
-
-    @property
-    def icon(self) -> str:
-        return "mdi:play-circle" if self.is_on else "mdi:pause-circle"
-
-
-class VeeamProxyOutOfDateSensor(VeeamProxyBinarySensorBase):
-    """Binary sensor for a proxy running outdated components."""
-
-    _attr_device_class = BinarySensorDeviceClass.PROBLEM
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator, config_entry, proxy_data):
-        super().__init__(coordinator, config_entry, proxy_data)
-        self._attr_unique_id = f"{config_entry.entry_id}_proxy_{self._proxy_id}_out_of_date"
-        self._attr_name = "Out Of Date"
-
-    @property
-    def is_on(self) -> bool | None:
-        proxy = self._proxy()
-        return proxy.get("is_out_of_date") if proxy else None
 
 
 class VeeamProxyTypeSensor(VeeamProxyBaseSensor):

--- a/tests/test_binary_sensor_platform.py
+++ b/tests/test_binary_sensor_platform.py
@@ -1,0 +1,119 @@
+"""Tests for the binary sensor platform.
+
+Home Assistant derives an entity domain from the platform that creates it, not from the entity
+class. BinarySensorEntity subclasses added by the sensor platform therefore landed in the sensor
+domain, where the binary-sensor device class wording never applies and every one of them
+displayed as a raw "on"/"off" — which is what was reported.
+
+In the binary_sensor domain the same entities read as Connected/Disconnected, OK/Problem and
+Running/Not running, with no per-entity strings to maintain.
+"""
+
+from pathlib import Path
+import re
+
+import pytest
+
+COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
+BINARY_PATH = COMPONENT / "binary_sensor.py"
+SENSOR_PATH = COMPONENT / "sensor.py"
+INIT_PATH = COMPONENT / "__init__.py"
+BLUEPRINTS = Path(__file__).parent.parent / "blueprints" / "automation" / "veeam_br"
+
+
+def binary_source():
+    return BINARY_PATH.read_text(encoding="utf-8")
+
+
+def test_the_platform_exists_and_is_registered():
+    """Without the platform in PLATFORMS, nothing sets these entities up at all."""
+    assert BINARY_PATH.exists()
+
+    init = INIT_PATH.read_text(encoding="utf-8")
+    assert "Platform.BINARY_SENSOR" in init
+
+
+def test_no_binary_entities_are_left_on_the_sensor_platform():
+    """A BinarySensorEntity created by the sensor platform is the original bug."""
+    sensor = SENSOR_PATH.read_text(encoding="utf-8")
+
+    assert "BinarySensorEntity" not in sensor
+    assert "BinarySensorDeviceClass" not in sensor
+
+
+def test_every_binary_sensor_moved():
+    """All sixteen, not just the proxy ones that prompted the report."""
+    source = binary_source()
+    concrete = re.findall(r"^class (Veeam\w+)\(.*Base\):", source, re.M)
+
+    assert len(concrete) >= 16, f"only found {concrete}"
+
+
+@pytest.mark.parametrize(
+    "entity,device_class",
+    [
+        ("VeeamProxyOnlineSensor", "CONNECTIVITY"),
+        ("VeeamProxyOutOfDateSensor", "PROBLEM"),
+        ("VeeamRepositoryOnlineStatusSensor", "CONNECTIVITY"),
+        ("VeeamServerConnectedSensor", "CONNECTIVITY"),
+        ("VeeamHAClusterOnlineSensor", "CONNECTIVITY"),
+        ("VeeamHAClusterFailoverInProgressSensor", "RUNNING"),
+    ],
+)
+def test_device_classes_supply_the_wording(entity, device_class):
+    """The device class is what turns on/off into readable text, so each one needs the right
+    class rather than a hand-written label."""
+    source = binary_source()
+    block = source[source.index(f"class {entity}(") :]
+    block = block[: block.index("\n\nclass ")] if "\n\nclass " in block else block
+
+    assert f"BinarySensorDeviceClass.{device_class}" in block
+
+
+def test_enabled_has_no_device_class_and_says_why():
+    """There is no "enabled/disabled" device class, so this one keeps a custom icon instead."""
+    source = binary_source()
+    block = source[source.index("class VeeamProxyEnabledSensor") :]
+    block = block[: block.index("\n\nclass ")]
+
+    assert "BinarySensorDeviceClass" not in block
+    assert "def icon" in block
+
+
+def test_old_sensor_entities_are_cleaned_up_on_upgrade():
+    """The unique IDs do not change, only the domain, so both would otherwise coexist and the
+    stale one would sit there unavailable forever."""
+    source = binary_source()
+
+    assert "_drop_superseded_sensor_entities" in source
+    block = source[source.index("def _drop_superseded_sensor_entities") :]
+    block = block[: block.index("async def async_setup_entry")]
+
+    assert 'existing.domain != "sensor"' in block, "only sensor-domain strays should be removed"
+    assert "existing.unique_id not in unique_ids" in block, "matching should be by unique ID"
+    assert "registry.async_remove" in block
+    assert "_LOGGER.info" in block, "an entity id changing under the user deserves a log line"
+
+
+def test_the_blueprints_can_now_find_these_entities():
+    """Three shipped blueprints filter on domain: binary_sensor, which matched nothing while
+    the entities lived in the sensor domain."""
+    filters = 0
+    for path in sorted(BLUEPRINTS.glob("*.yaml")):
+        filters += path.read_text(encoding="utf-8").count("domain: binary_sensor")
+
+    assert filters >= 3, "the proxy and HA cluster blueprints depend on this domain"
+
+
+def test_mixins_are_reused_rather_than_duplicated():
+    """Device grouping has to match the sensor platform exactly, or a proxy shows up twice."""
+    source = binary_source()
+
+    assert "from .sensor import (" in source
+    for mixin in (
+        "VeeamHAClusterMixin",
+        "VeeamLicenseMixin",
+        "VeeamProxyMixin",
+        "VeeamRepositoryMixin",
+    ):
+        assert mixin in source

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -15,6 +15,7 @@ COMPONENT = Path(__file__).parent.parent / "custom_components" / "veeam_br"
 INIT_PATH = COMPONENT / "__init__.py"
 SENSOR_PATH = COMPONENT / "sensor.py"
 BUTTON_PATH = COMPONENT / "button.py"
+BINARY_PATH = COMPONENT / "binary_sensor.py"
 
 
 def _load_display():
@@ -97,15 +98,16 @@ def test_both_kinds_reach_the_coordinator_payload():
 def test_entities_are_gated_on_the_endpoint_existing():
     """Neither endpoint is present in every API revision the library ships."""
     sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
+    binary_source = BINARY_PATH.read_text(encoding="utf-8")
 
-    assert 'check_api_feature_availability(api_version, "api.proxies")' in sensor_source
+    assert 'check_api_feature_availability(api_version, "api.proxies")' in binary_source
     assert 'check_api_feature_availability(api_version, "api.wan_accelerators")' in sensor_source
 
 
 def test_proxy_enabled_is_reported_the_healthy_way_round():
     """The API reports isDisabled; a sensor called "Disabled" would show red when fine."""
-    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
-    block = sensor_source[sensor_source.index("class VeeamProxyEnabledSensor") :]
+    binary_source = BINARY_PATH.read_text(encoding="utf-8")
+    block = binary_source[binary_source.index("class VeeamProxyEnabledSensor") :]
     block = block[: block.index("class VeeamProxyOutOfDate")]
 
     assert 'self._attr_name = "Enabled"' in block
@@ -131,15 +133,17 @@ def test_proxy_buttons_are_config_entities():
 
 
 def test_proxy_entities_share_one_device_per_proxy():
-    """Sensors and buttons must agree on the identifier or they split into two devices."""
-    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
-    button_source = BUTTON_PATH.read_text(encoding="utf-8")
+    """Every platform must agree on the identifier or they split into separate devices."""
+    sources = [
+        SENSOR_PATH.read_text(encoding="utf-8"),
+        BUTTON_PATH.read_text(encoding="utf-8"),
+    ]
 
     identifier = 'f"proxy_{self._proxy_id}"'
-    assert identifier in sensor_source
-    assert identifier in button_source
+    for source in sources:
+        assert identifier in source
 
-    for source in (sensor_source, button_source):
+    for source in sources:
         block = source[source.index(identifier) - 400 : source.index(identifier) + 400]
         assert '"model": "Backup Proxy"' in block
 


### PR DESCRIPTION
Online, Enabled and Out Of Date displayed as raw "on"/"off". The cause was not the labels: these were BinarySensorEntity subclasses handed to the sensor platform, and Home Assistant derives an entity domain from the platform that creates it, not from the class. They therefore lived in the sensor domain, where the binary-sensor device class wording is never applied.

In their own platform the same entities read as Connected/Disconnected, OK/Problem and Running/Not running, supplied by Home Assistant from the device class with no per-entity strings to maintain. All sixteen moved, not only the three proxy ones that prompted this: repository online, out-of-date, immutable, accessible and the two capacity warnings, server health and connectivity, license auto-update and cloud connect, and the three HA cluster sensors.

Two consequences worth knowing.

The entity IDs move from sensor.* to binary_sensor.*. Unique IDs are unchanged, so Home Assistant would otherwise keep both — the old one stranded and unavailable forever, since nothing provides it. Each replacement removes its predecessor by unique ID and logs it, so one upgrade migrates rather than duplicates. Automations and dashboards referencing the old IDs need updating; the README says so.

It also fixes three shipped blueprints. proxy_offline and ha_cluster_failover filter their entity selectors on domain: binary_sensor, which matched nothing at all while these entities were in the sensor domain.

Proxy Enabled keeps a custom icon rather than a device class, because there is no enabled/disabled class and PROBLEM would colour a deliberately disabled proxy red.