### PR TITLE
Fix VBR 12.x (API 1.2-rev1) compatibility: proxies, null enums, opaque parse errors

### DIFF
--- a/custom_components/veeam_br/__init__.py
+++ b/custom_components/veeam_br/__init__.py
@@ -40,6 +40,11 @@ PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.B
 # High Availability cluster endpoints exist only from API 1.3-rev2 (VBR 13.1)
 HA_CLUSTER_FEATURE = "api.high_availability_ha_cluster"
 
+# The proxy states endpoint arrived in API 1.3-rev0 (VBR 13). On 1.2-rev1 and older only
+# the configuration endpoint exists, so online/disabled/out-of-date are simply unknown
+# there rather than the whole proxy fetch failing (issue #104).
+PROXY_STATES_FEATURE = "api.proxies.get_all_proxies_states"
+
 
 def _bool_or_none(obj, name: str) -> bool | None:
     """Read a boolean off a model, mapping UNSET and anything unexpected to None."""
@@ -449,6 +454,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ha_cluster_supported = check_api_feature_availability(api_version, HA_CLUSTER_FEATURE)
     _LOGGER.debug("HA cluster endpoints available on %s: %s", api_version, ha_cluster_supported)
 
+    proxy_states_supported = check_api_feature_availability(api_version, PROXY_STATES_FEATURE)
+    proxies_endpoint = "get_all_proxies_states" if proxy_states_supported else "get_all_proxies"
+    _LOGGER.debug("Proxy states endpoint available on %s: %s", api_version, proxy_states_supported)
+
     api_endpoints = [
         "jobs.get_all_jobs_states",
         "service.get_server_info",
@@ -456,7 +465,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "repositories.get_all_repositories",
         "repositories.get_all_repositories_states",
         "repositories.get_all_scale_out_repositories",
-        "proxies.get_all_proxies_states",
+        f"proxies.{proxies_endpoint}",
         "wan_accelerators.get_all_wan_accelerators",
     ]
     if ha_cluster_supported:
@@ -923,11 +932,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug("Total SOBRs added to coordinator data: %d", len(sobr_list))
 
             # Fetch backup proxies. The states endpoint carries the configuration this needs
-            # as well as online/disabled/out-of-date, so one call covers both.
+            # as well as online/disabled/out-of-date, so one call covers both — where it
+            # exists. Before 1.3-rev0 there is only the configuration endpoint, and the
+            # three state fields read back as None (issue #104).
             proxies_list = []
             try:
                 proxies_api = await asyncio.to_thread(veeam_client.api, "proxies")
-                proxies_result = await veeam_client.call(proxies_api.get_all_proxies_states)
+                proxies_result = await veeam_client.call(getattr(proxies_api, proxies_endpoint))
 
                 for proxy in getattr(proxies_result, "data", None) or []:
                     try:

--- a/custom_components/veeam_br/binary_sensor.py
+++ b/custom_components/veeam_br/binary_sensor.py
@@ -101,7 +101,10 @@ async def async_setup_entry(
                 )
                 added_repository_ids.add(repo_id)
 
-        if check_api_feature_availability(api_version, "api.proxies"):
+        # All three of these read fields that only the proxy states endpoint returns, and
+        # that endpoint arrived in 1.3-rev0 — on an older server they would be permanently
+        # unknown, so the entities are not created at all (issue #104).
+        if check_api_feature_availability(api_version, "api.proxies.get_all_proxies_states"):
             for proxy in coordinator.data.get("proxies", []):
                 proxy_id = proxy.get("id")
                 if not proxy_id or proxy_id in added_proxy_ids:

--- a/custom_components/veeam_br/button.py
+++ b/custom_components/veeam_br/button.py
@@ -176,7 +176,9 @@ async def async_setup_entry(
                     )
 
         # ---- PROXY BUTTONS - a proxy can be taken out of service without deleting it ----
-        if check_api_feature_availability(api_version, "api.proxies"):
+        # enable_proxy/disable_proxy arrived in 1.3-rev0; api.proxies alone is not enough,
+        # since older versions expose the namespace without those two operations (#104)
+        if check_api_feature_availability(api_version, "api.proxies.enable_proxy"):
             for proxy in coordinator.data.get("proxies", []):
                 proxy_id = proxy.get("id")
                 if not proxy_id or proxy_id in added_proxy_ids:

--- a/custom_components/veeam_br/const.py
+++ b/custom_components/veeam_br/const.py
@@ -152,8 +152,11 @@ API_FEATURE_REQUIREMENTS = {
     "license_data": "api.license_",
     "server_data": "api.service",
     "proxy_data": "api.proxies",
-    "proxy_enable_button": "api.proxies",
-    "proxy_disable_button": "api.proxies",
+    # Proxy state (online/disabled/out-of-date) and the enable/disable operations:
+    # API 1.3-rev0 (VBR 13) and newer only
+    "proxy_state_data": "api.proxies.get_all_proxies_states",
+    "proxy_enable_button": "api.proxies.enable_proxy",
+    "proxy_disable_button": "api.proxies.disable_proxy",
     "wan_accelerator_data": "api.wan_accelerators",
     # High Availability cluster: API 1.3-rev2 (VBR 13.1) and newer only
     "ha_cluster_data": "api.high_availability_ha_cluster",

--- a/custom_components/veeam_br/sdk_patches.py
+++ b/custom_components/veeam_br/sdk_patches.py
@@ -3,7 +3,7 @@
 Veeam's published schema declares many properties non-nullable that the server nonetheless
 sends as ``null``. The generated models reproduce the schema faithfully, so each such null
 raises while parsing — and because a response is parsed as a whole, one null makes the
-entire endpoint's data disappear. Three shapes of this have been reported:
+entire endpoint's data disappear. Four shapes of this have been reported:
 
 * a null timestamp — ``isoparse(None)`` raises
   ``TypeError: object of type 'NoneType' has no len()``. VBR sends ``"nextRun": null`` for
@@ -17,6 +17,10 @@ entire endpoint's data disappear. Three shapes of this have been reported:
   ``TypeError: 'NoneType' object is not iterable``, because from_dict starts with
   ``dict(src_dict)``. VBR sends ``"instanceLicenseSummary": null`` when that summary does
   not apply, which lost all license data (issue #82).
+* a null enum — ``ELicensePackageType(None)`` raises
+  ``ValueError: None is not a valid ELicensePackageType``. VBR sends ``"package": null`` in
+  the instance license summary of a server running on the evaluation period, so a server
+  with no license installed had no license data at all (issue #104).
 
 Each patch maps a null onto ``UNSET``, the sentinel the generated code already uses for an
 absent field: ``to_dict`` skips it and this integration already reads it as None. Nothing
@@ -29,14 +33,23 @@ progress rates in SessionProgressType0 (nested in JobStateModel), where a null i
 input and dropping the key raises KeyError instead.
 
 Generated model modules do ``from dateutil.parser import isoparse`` / ``from uuid import
-UUID`` and call them by those names, so rebinding the names per module changes only that
-module's parsing — patching ``dateutil`` or ``uuid`` globally would affect every other
-integration in the process.
+UUID`` / ``from ..models.e_thing import EThing`` and call them by those names, so rebinding
+the names per module changes only that module's parsing — patching ``dateutil``, ``uuid``
+or a shared enum class globally would affect every other importer of it.
+
+Deliberately *not* made tolerant: a ``from_dict`` handed something that is not an object at
+all. That is not a null, it is a payload of an unexpected shape, and swallowing it would
+hide a real protocol mismatch. What is added is a name for it: the generated
+``dict(src_dict)`` reports a string or a list as ``ValueError: dictionary update sequence
+element #0 has length 1; 2 is required``, which identifies neither the model nor the value,
+and has now been reported twice without either being recoverable from the log (issues #80
+and #104). It is re-raised carrying both.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
+from enum import Enum
 import logging
 from types import ModuleType
 from typing import Any
@@ -45,6 +58,11 @@ _LOGGER = logging.getLogger(__name__)
 
 # Marker set on a patched module so re-running is free and idempotent
 PATCH_MARKER = "_ha_veeam_br_null_tolerance_patched"
+
+# How much of an unexpected payload to quote when from_dict is handed a non-object. Enough
+# to recognize an error string or a HATEOAS link, short enough not to spill a whole
+# response — or any credential inside one — into the log.
+UNEXPECTED_PAYLOAD_CHARS = 200
 
 
 def _patch_parsers(module: ModuleType, unset: Any) -> None:
@@ -70,11 +88,61 @@ def _patch_parsers(module: ModuleType, unset: Any) -> None:
         setattr(module, "UUID", tolerant_uuid)
 
 
+class _NullTolerantEnum:
+    """Stand-in for an enum class that reads a null as absent.
+
+    Generated code uses the enum name in three ways: as a constructor, to reach a member
+    (``EJobType.BACKUP``), and in annotations — which are strings here, since every model
+    module starts with ``from __future__ import annotations``. The first is intercepted and
+    the second delegated, so the substitution is invisible to the rest of the module.
+
+    ``isinstance`` against the name would break, but no generated model module does that —
+    the parsed value is compared against ``Unset``, never against its own enum class.
+    """
+
+    def __init__(self, enum_class: type[Enum], unset: Any) -> None:
+        self._enum_class = enum_class
+        self._unset = unset
+
+    def __call__(self, value: Any = None, *args: Any, **kwargs: Any) -> Any:
+        if value is None and not args and not kwargs:
+            return self._unset
+        return self._enum_class(value, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._enum_class, name)
+
+    def __repr__(self) -> str:
+        return f"<null-tolerant {self._enum_class.__name__}>"
+
+
+def _patch_enums(module: ModuleType, unset: Any) -> None:
+    """Rebind the enum classes this module parses with so a null parses as absent.
+
+    The enum class itself is left alone: it is shared by every model module that imports
+    it, and by the integration's own code, which compares real members against it. Only
+    imported names are rebound — an enum's own defining module keeps the real class, so
+    anything importing it afterwards still gets the enum rather than the stand-in.
+    """
+    for name, attribute in list(vars(module).items()):
+        if _is_imported_enum(attribute, module):
+            setattr(module, name, _NullTolerantEnum(attribute, unset))
+
+
+def _is_imported_enum(attribute: Any, module: ModuleType) -> bool:
+    """Whether this module-level name is an enum class defined somewhere else."""
+    return (
+        isinstance(attribute, type)
+        and issubclass(attribute, Enum)
+        and attribute.__module__ != module.__name__
+    )
+
+
 def _patch_from_dict(module: ModuleType, unset: Any) -> None:
     """Make the module's model classes read a null object as absent.
 
     Only the null case is intercepted; a real payload goes to the generated from_dict
-    untouched.
+    untouched. A payload that is neither null nor an object still fails, but is named.
     """
     for attribute in list(vars(module).values()):
         if not isinstance(attribute, type) or attribute.__module__ != module.__name__:
@@ -88,9 +156,22 @@ def _patch_from_dict(module: ModuleType, unset: Any) -> None:
         def tolerant_from_dict(cls: type, src_dict: Any, _original=original) -> Any:
             if src_dict is None:
                 return unset
+            if not isinstance(src_dict, Mapping):
+                raise TypeError(_describe_unexpected_payload(cls, src_dict))
             return _original(cls, src_dict)
 
         attribute.from_dict = classmethod(tolerant_from_dict)
+
+
+def _describe_unexpected_payload(cls: type, src_dict: Any) -> str:
+    """Explain a from_dict payload that is not a JSON object."""
+    quoted = repr(src_dict)
+    if len(quoted) > UNEXPECTED_PAYLOAD_CHARS:
+        quoted = f"{quoted[:UNEXPECTED_PAYLOAD_CHARS]}..."
+    return (
+        f"{cls.__name__} expected a JSON object but the server sent "
+        f"{type(src_dict).__name__} {quoted}"
+    )
 
 
 def patch_null_values(module: ModuleType, unset: Any) -> bool:
@@ -103,16 +184,18 @@ def patch_null_values(module: ModuleType, unset: Any) -> bool:
         return False
 
     has_parsers = hasattr(module, "isoparse") or hasattr(module, "UUID")
+    has_enums = any(_is_imported_enum(attribute, module) for attribute in vars(module).values())
     has_models = any(
         isinstance(attribute, type)
         and attribute.__module__ == module.__name__
         and hasattr(attribute, "from_dict")
         for attribute in vars(module).values()
     )
-    if not has_parsers and not has_models:
+    if not has_parsers and not has_enums and not has_models:
         return False
 
     _patch_parsers(module, unset)
+    _patch_enums(module, unset)
     _patch_from_dict(module, unset)
     setattr(module, PATCH_MARKER, True)
     return True

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -1,8 +1,10 @@
 """Tests for backup proxy and WAN accelerator support.
 
 Proxy figures come from get_all_proxies_states, which carries both the configuration and the
-live state, so one call feeds every proxy entity. WAN accelerators have no states endpoint, so
-those entities are configuration only.
+live state, so one call feeds every proxy entity — on API 1.3-rev0 and newer. Older servers
+have only get_all_proxies, so there the proxies are configuration only and the state entities
+are not created. WAN accelerators have no states endpoint on any version, so those entities
+are configuration only throughout.
 """
 
 import importlib.util
@@ -46,7 +48,33 @@ def test_proxies_are_fetched_from_the_states_endpoint():
     source = INIT_PATH.read_text(encoding="utf-8")
 
     assert "get_all_proxies_states" in source
-    assert "proxies.get_all_proxies_states" in source, "should be pre-imported like the others"
+    assert 'f"proxies.{proxies_endpoint}"' in source, "should be pre-imported like the others"
+
+
+def test_proxy_endpoint_falls_back_when_states_is_missing():
+    """The states endpoint arrived in 1.3-rev0; before that only get_all_proxies exists.
+
+    Asking for it anyway raised ModuleNotFoundError on every poll and lost the proxy
+    entities entirely on VBR 12.x (issue #104).
+    """
+    source = INIT_PATH.read_text(encoding="utf-8")
+
+    assert 'PROXY_STATES_FEATURE = "api.proxies.get_all_proxies_states"' in source
+    assert "check_api_feature_availability(api_version, PROXY_STATES_FEATURE)" in source
+    assert '"get_all_proxies_states" if proxy_states_supported else "get_all_proxies"' in source
+    assert "getattr(proxies_api, proxies_endpoint)" in source
+
+
+@pytest.mark.parametrize(
+    "package,expected",
+    [("veeam_br.v1_2_rev1", False), ("veeam_br.v1_3_rev0", True)],
+)
+def test_states_endpoint_presence_matches_what_the_fallback_assumes(package, expected):
+    """The fallback is only correct if 1.2-rev1 really lacks the endpoint and 1.3 has it."""
+    pytest.importorskip(package, reason="veeam-br not installed")
+
+    found = importlib.util.find_spec(f"{package}.api.proxies.get_all_proxies_states")
+    assert (found is not None) is expected
 
 
 def test_proxy_state_flags_are_read_as_booleans_or_unknown():
@@ -96,11 +124,25 @@ def test_both_kinds_reach_the_coordinator_payload():
 
 
 def test_entities_are_gated_on_the_endpoint_existing():
-    """Neither endpoint is present in every API revision the library ships."""
+    """Neither endpoint is present in every API revision the library ships.
+
+    The proxy binary sensors read state fields that only the states endpoint returns, and
+    the enable/disable buttons call operations that arrived with it, so both are gated on
+    that endpoint rather than on the api.proxies namespace — which exists further back and
+    would leave three permanently unknown sensors and two failing buttons (issue #104).
+    """
     sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
     binary_source = BINARY_PATH.read_text(encoding="utf-8")
+    button_source = BUTTON_PATH.read_text(encoding="utf-8")
 
-    assert 'check_api_feature_availability(api_version, "api.proxies")' in binary_source
+    assert (
+        'check_api_feature_availability(api_version, "api.proxies.get_all_proxies_states")'
+        in binary_source
+    )
+    assert (
+        'check_api_feature_availability(api_version, "api.proxies.enable_proxy")'
+        in button_source
+    )
     assert 'check_api_feature_availability(api_version, "api.wan_accelerators")' in sensor_source
 
 

--- a/tests/test_sdk_patches.py
+++ b/tests/test_sdk_patches.py
@@ -300,3 +300,123 @@ def test_patch_models_ignores_other_packages_and_none_entries():
 
     assert patched == 1
     assert not getattr(other, sdk_patches.PATCH_MARKER, False), "other packages untouched"
+
+
+# ---------------------------------------------------------------------------
+# Null enum — VBR sends "package": null on an unlicensed server (#104)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("package", sorted(set(veeam_br_versions.values())))
+def test_null_enum_fails_before_patch_and_parses_after(package):
+    """The license error from issue #104, reported by a server in evaluation mode."""
+    sdk_patches = _load_sdk_patches()
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    module = _fresh_model_module(package, "instance_license_summary_model")
+    real = list(module.ELicensePackageType)[0]
+
+    with pytest.raises(ValueError, match="None is not a valid ELicensePackageType"):
+        module.ELicensePackageType(None)
+
+    assert sdk_patches.patch_null_values(module, unset) is True
+
+    assert module.ELicensePackageType(None) is unset, "a null enum should read as absent"
+    assert module.ELicensePackageType(real.value) is real, "real values must still parse"
+
+
+@pytest.mark.parametrize("package", sorted(set(veeam_br_versions.values())))
+def test_null_package_no_longer_empties_the_license_summary(package):
+    """The blast radius: one null enum lost every license figure on the server."""
+    sdk_patches = _load_sdk_patches()
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    module = _fresh_model_module(package, "instance_license_summary_model")
+    payload = {
+        "licensedInstancesNumber": 10,
+        "usedInstancesNumber": 4,
+        "newInstancesNumber": 0,
+        "rentalInstancesNumber": 0,
+        "package": None,
+    }
+
+    with pytest.raises(ValueError, match="None is not a valid ELicensePackageType"):
+        module.InstanceLicenseSummaryModel.from_dict(dict(payload))
+
+    assert sdk_patches.patch_null_values(module, unset) is True
+
+    summary = module.InstanceLicenseSummaryModel.from_dict(dict(payload))
+    assert summary.package is unset
+    assert summary.licensed_instances_number == 10, "the rest of the summary should survive"
+
+
+def test_enum_members_are_still_reachable_through_the_patched_name():
+    """Generated code reaches members off the module-level name, not only the class."""
+    sdk_patches = _load_sdk_patches()
+    package = sorted(set(veeam_br_versions.values()))[0]
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    module = _fresh_model_module(package, "job_state_model")
+    before = module.EJobType.BACKUP
+
+    assert sdk_patches.patch_null_values(module, unset) is True
+
+    assert module.EJobType.BACKUP is before, "member access must pass through unchanged"
+
+
+def test_the_enum_class_itself_is_left_alone():
+    """The stand-in must not leak: the enum is shared by every module that imports it."""
+    sdk_patches = _load_sdk_patches()
+    package = sorted(set(veeam_br_versions.values()))[0]
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    defining_module = _fresh_model_module(package, "e_job_type")
+    real = defining_module.EJobType
+
+    sdk_patches.patch_null_values(defining_module, unset)
+
+    assert defining_module.EJobType is real, "an enum's own module keeps the real class"
+
+
+# ---------------------------------------------------------------------------
+# A payload that is not an object at all — named rather than made tolerant (#80, #104)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["Unauthorized", ["a"], 42],
+    ids=["error-string", "list", "number"],
+)
+def test_a_non_object_payload_is_reported_with_the_model_and_the_value(payload):
+    """dict("Unauthorized") says only "sequence element #0 has length 1" (#80, #104)."""
+    sdk_patches = _load_sdk_patches()
+    package = sorted(set(veeam_br_versions.values()))[0]
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    module = _fresh_model_module(package, "job_states_result")
+    assert sdk_patches.patch_null_values(module, unset) is True
+
+    with pytest.raises(TypeError) as raised:
+        module.JobStatesResult.from_dict(payload)
+
+    message = str(raised.value)
+    assert "JobStatesResult" in message, "the model must be named"
+    assert type(payload).__name__ in message
+    assert repr(payload) in message, "the offending value must be quoted"
+
+
+def test_a_huge_non_object_payload_is_truncated():
+    """A whole response body — or a credential inside one — must not reach the log."""
+    sdk_patches = _load_sdk_patches()
+    package = sorted(set(veeam_br_versions.values()))[0]
+    unset = importlib.import_module(f"{package}.types").UNSET
+
+    module = _fresh_model_module(package, "job_states_result")
+    sdk_patches.patch_null_values(module, unset)
+
+    with pytest.raises(TypeError) as raised:
+        module.JobStatesResult.from_dict("x" * 10_000)
+
+    assert len(str(raised.value)) < sdk_patches.UNEXPECTED_PAYLOAD_CHARS + 200
+    assert str(raised.value).endswith("...")


### PR DESCRIPTION
Fixes the three warnings reported in #104 from a VBR 12.3.2.4854 server on API `1.2-rev1`, no license installed.

## Changes

**Proxies asked for endpoints that only exist on 1.3-rev0 and newer**

`get_all_proxies_states`, `enable_proxy` and `disable_proxy` arrived in 1.3-rev0. The states endpoint was requested unconditionally, so on 1.2-rev1 every poll raised `No module named 'veeam_br.v1_2_rev1.api.proxies.get_all_proxies_states'` and all proxy entities disappeared.

- The endpoint is now chosen by `check_api_feature_availability` and falls back to `get_all_proxies`, which carries the configuration but not `isOnline`/`isDisabled`/`isOutOfDate`.
- The three proxy binary sensors and the enable/disable buttons were gated on the `api.proxies` namespace, which exists much further back. They now gate on the operations themselves, so an older server gets neither three permanently-unknown sensors nor two buttons that always fail.

**A null enum emptied the license data**

A server running on the evaluation period sends `"package": null` in the instance license summary, which hit `ELicensePackageType(None)` → `ValueError: None is not a valid ELicensePackageType`, and — because a response is parsed as a whole — lost every license figure.

`sdk_patches` already mapped null timestamps, UUIDs and nested objects onto `UNSET`; it now does the same for enums, rebinding the enum names a model module parses with. Only *imported* names are rebound, so an enum's own defining module keeps the real class and every other importer — including this integration's own comparisons — is unaffected. Member access and `isinstance` still work, verified end-to-end against the installed SDK.

**`dictionary update sequence element #0 has length 1; 2 is required` is now diagnosable**

This is Python's error when `dict()` gets a non-mapping, raised by the generated `from_dict`. It was reported before in #80, and PR #81 absorbed it into a warning without ever identifying the payload — so two reports later we still don't know what the server sent.

This is deliberately **not** made tolerant: a `from_dict` handed something that isn't an object is a protocol mismatch, not a null, and swallowing it would hide a real problem. What's added is a name for it — the error now reads:

```
JobStatesResult expected a JSON object but the server sent str 'Unauthorized'
```

truncated at 200 chars so a whole response body (or a credential inside one) can't reach the log. **The root cause of #104's second warning is still unknown**; this makes the next report name it on the first line.

## Tests

12 new tests across `test_sdk_patches.py` and `test_proxies.py`, including one that asserts 1.2-rev1 genuinely lacks the states endpoint and 1.3-rev0 has it, so the fallback can't silently rot. Two tests that asserted the old proxy gating were updated. 339 pass.

Refs #104, #80
